### PR TITLE
'dlink-client-hadoop打包增加ServicesResourceTransformer'

### DIFF
--- a/dlink-client/dlink-client-hadoop/pom.xml
+++ b/dlink-client/dlink-client-hadoop/pom.xml
@@ -146,6 +146,7 @@
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                             <filters>
                                 <filter>


### PR DESCRIPTION
自动合并META-INFO/services目录下的文件，解决因文件覆盖导致的异常。
例如：META-INFO/services/org.apache.hadoop.fs.FileSystem没有合并导致的 No FileSystem for scheme “hdfs“  异常