### PR TITLE
fix(sec): upgrade mysql-connector-java to 8.0.28

### DIFF
--- a/dlink-extends/dependency-reduced-pom.xml
+++ b/dlink-extends/dependency-reduced-pom.xml
@@ -70,7 +70,7 @@
     <derby.version>10.14.2.0</derby.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mariaDB4j.version>2.4.0</mariaDB4j.version>
-    <mysql-connector-java.version>8.0.22</mysql-connector-java.version>
+    <mysql-connector-java.version>8.0.28</mysql-connector-java.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <ojdbc8.version>12.2.0.1</ojdbc8.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <lombok.version>1.18.16</lombok.version>
         <jackjson.version>2.12.1</jackjson.version>
         <guava.version>21.0</guava.version>
-        <mysql-connector-java.version>8.0.22</mysql-connector-java.version>
+        <mysql-connector-java.version>8.0.28</mysql-connector-java.version>
         <ojdbc8.version>12.2.0.1</ojdbc8.version>
         <clickhouse.version>0.2.6</clickhouse.version>
         <postgresql.version>42.2.14</postgresql.version>


### PR DESCRIPTION
Upgrade mysql-connector-java from 8.0.22 to 8.0.28 for vulnerability fix:
- [CVE-2021-2471](https://www.oscs1024.com/hd/MPS-2021-45509)
- [CVE-2022-21363](https://www.oscs1024.com/hd/MPS-2021-36587)