### PR TITLE
[Fix-1130][metadata]AWS RDS PostGreSQL can't get schema

### DIFF
--- a/dlink-metadata/dlink-metadata-postgresql/src/main/java/com/dlink/metadata/query/PostgreSqlQuery.java
+++ b/dlink-metadata/dlink-metadata-postgresql/src/main/java/com/dlink/metadata/query/PostgreSqlQuery.java
@@ -28,7 +28,7 @@ package com.dlink.metadata.query;
 public class PostgreSqlQuery extends AbstractDBQuery {
     @Override
     public String schemaAllSql() {
-        return "SELECT \"schema_name\" FROM information_schema.schemata where \"schema_name\" not in ('pg_toast','pg_temp_1','pg_toast_temp_1','pg_catalog','information_schema')";
+        return "SELECT nspname AS \"schema_name\" FROM pg_namespace WHERE nspname NOT LIKE 'pg_%' AND nspname != 'information_schema'";
     }
 
     @Override


### PR DESCRIPTION
## 修复 kafka sink 配置 peoperties 未生效问题

- DorisSink 重写了 `getProperties()`  方法
- flink 1.13之前版本
    - 使用 `FlinkKafkaProducer` 含 perperties 构造参数创建 Sink
- flink 1.14 之后的版本
    - 使用 `KafkaSink.setKafkaProducerConfig()` 注入

> 目前我本人只测试了 1.14 版本的效果，其它版本未进行测试