### PR TITLE
[Feature][Auto Create Mysql table] MySQL automatically creates tables consistent with the original tables

### DIFF
--- a/dlink-common/src/main/java/com/dlink/model/Column.java
+++ b/dlink-common/src/main/java/com/dlink/model/Column.java
@@ -46,6 +46,7 @@ public class Column implements Serializable {
     private ColumnType javaType;
     private String columnFamily;
     private Integer position;
+    private Integer length;
     private Integer precision;
     private Integer scale;
     private String characterSet;

--- a/dlink-metadata/dlink-metadata-base/src/main/java/com/dlink/metadata/driver/AbstractJdbcDriver.java
+++ b/dlink-metadata/dlink-metadata-base/src/main/java/com/dlink/metadata/driver/AbstractJdbcDriver.java
@@ -19,6 +19,10 @@
 
 package com.dlink.metadata.driver;
 
+import static com.dlink.utils.SplitUtil.contains;
+import static com.dlink.utils.SplitUtil.getReValue;
+import static com.dlink.utils.SplitUtil.isSplit;
+
 import com.dlink.assertion.Asserts;
 import com.dlink.constant.CommonConstant;
 import com.dlink.metadata.query.IDBQuery;
@@ -60,10 +64,6 @@ import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.pool.DruidPooledConnection;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
-
-import static com.dlink.utils.SplitUtil.contains;
-import static com.dlink.utils.SplitUtil.getReValue;
-import static com.dlink.utils.SplitUtil.isSplit;
 
 /**
  * AbstractJdbcDriver

--- a/dlink-metadata/dlink-metadata-base/src/main/java/com/dlink/metadata/driver/AbstractJdbcDriver.java
+++ b/dlink-metadata/dlink-metadata-base/src/main/java/com/dlink/metadata/driver/AbstractJdbcDriver.java
@@ -19,10 +19,6 @@
 
 package com.dlink.metadata.driver;
 
-import static com.dlink.utils.SplitUtil.contains;
-import static com.dlink.utils.SplitUtil.getReValue;
-import static com.dlink.utils.SplitUtil.isSplit;
-
 import com.dlink.assertion.Asserts;
 import com.dlink.constant.CommonConstant;
 import com.dlink.metadata.query.IDBQuery;
@@ -64,6 +60,10 @@ import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.pool.DruidPooledConnection;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
+
+import static com.dlink.utils.SplitUtil.contains;
+import static com.dlink.utils.SplitUtil.getReValue;
+import static com.dlink.utils.SplitUtil.isSplit;
 
 /**
  * AbstractJdbcDriver
@@ -317,24 +317,26 @@ public abstract class AbstractJdbcDriver extends AbstractDriver {
                     String columnType = results.getString(dbQuery.columnType());
                     if (columnType.contains("(")) {
                         String type = columnType.replaceAll("\\(.*\\)", "");
-                        if(!columnType.contains(",")){
+                        if (!columnType.contains(",")) {
                             Integer length = Integer.valueOf(columnType.replaceAll("\\D", ""));
                             field.setLength(length);
-                        }else {
+                        } else {
                             // 例如浮点类型的长度和精度是一样的，decimal(10,2)
                             field.setLength(results.getInt(dbQuery.precision()));
                         }
                         field.setType(type);
-                    }else {
+                    } else {
                         field.setType(columnType);
                     }
                 }
-                if (columnList.contains(dbQuery.columnComment()) && Asserts.isNotNull(results.getString(dbQuery.columnComment()))) {
+                if (columnList.contains(dbQuery.columnComment())
+                        && Asserts.isNotNull(results.getString(dbQuery.columnComment()))) {
                     String columnComment = results.getString(dbQuery.columnComment()).replaceAll("\"|'", "");
                     field.setComment(columnComment);
                 }
                 if (columnList.contains(dbQuery.isNullable())) {
-                    field.setNullable(Asserts.isEqualsIgnoreCase(results.getString(dbQuery.isNullable()), dbQuery.nullableValue()));
+                    field.setNullable(Asserts.isEqualsIgnoreCase(results.getString(dbQuery.isNullable()),
+                            dbQuery.nullableValue()));
                 }
                 if (columnList.contains(dbQuery.characterSet())) {
                     field.setCharacterSet(results.getString(dbQuery.characterSet()));
@@ -352,7 +354,8 @@ public abstract class AbstractJdbcDriver extends AbstractDriver {
                     field.setScale(results.getInt(dbQuery.scale()));
                 }
                 if (columnList.contains(dbQuery.autoIncrement())) {
-                    field.setAutoIncrement(Asserts.isEqualsIgnoreCase(results.getString(dbQuery.autoIncrement()), "auto_increment"));
+                    field.setAutoIncrement(
+                            Asserts.isEqualsIgnoreCase(results.getString(dbQuery.autoIncrement()), "auto_increment"));
                 }
                 field.setJavaType(getTypeConvert().convert(field));
                 columns.add(field);
@@ -516,10 +519,10 @@ public abstract class AbstractJdbcDriver extends AbstractDriver {
         String limitEnd = queryData.getOption().getLimitEnd();
 
         StringBuilder optionBuilder = new StringBuilder()
-            .append("select * from ")
-            .append(queryData.getSchemaName())
-            .append(".")
-            .append(queryData.getTableName());
+                .append("select * from ")
+                .append(queryData.getSchemaName())
+                .append(".")
+                .append(queryData.getTableName());
 
         if (where != null && !where.equals("")) {
             optionBuilder.append(" where ").append(where);
@@ -535,9 +538,9 @@ public abstract class AbstractJdbcDriver extends AbstractDriver {
             limitEnd = "100";
         }
         optionBuilder.append(" limit ")
-            .append(limitStart)
-            .append(",")
-            .append(limitEnd);
+                .append(limitStart)
+                .append(",")
+                .append(limitEnd);
 
         return optionBuilder;
     }
@@ -577,7 +580,8 @@ public abstract class AbstractJdbcDriver extends AbstractDriver {
             while (results.next()) {
                 LinkedHashMap<String, Object> data = new LinkedHashMap<>();
                 for (int i = 0; i < columns.size(); i++) {
-                    data.put(columns.get(i).getName(), getTypeConvert().convertValue(results, columns.get(i).getName(), columns.get(i).getType()));
+                    data.put(columns.get(i).getName(),
+                            getTypeConvert().convertValue(results, columns.get(i).getName(), columns.get(i).getType()));
                 }
                 datas.add(data);
                 count++;
@@ -610,9 +614,11 @@ public abstract class AbstractJdbcDriver extends AbstractDriver {
         JdbcSelectResult result = JdbcSelectResult.buildResult();
         for (SQLStatement item : stmtList) {
             String type = item.getClass().getSimpleName();
-            if (type.toUpperCase().contains("SELECT") || type.toUpperCase().contains("SHOW") || type.toUpperCase().contains("DESC") || type.toUpperCase().contains("SQLEXPLAINSTATEMENT")) {
+            if (type.toUpperCase().contains("SELECT") || type.toUpperCase().contains("SHOW")
+                    || type.toUpperCase().contains("DESC") || type.toUpperCase().contains("SQLEXPLAINSTATEMENT")) {
                 result = query(item.toString(), limit);
-            } else if (type.toUpperCase().contains("INSERT") || type.toUpperCase().contains("UPDATE") || type.toUpperCase().contains("DELETE")) {
+            } else if (type.toUpperCase().contains("INSERT") || type.toUpperCase().contains("UPDATE")
+                    || type.toUpperCase().contains("DELETE")) {
                 try {
                     resList.add(executeUpdate(item.toString()));
                     result.setStatusList(resList);
@@ -666,8 +672,9 @@ public abstract class AbstractJdbcDriver extends AbstractDriver {
         PreparedStatement preparedStatement = null;
         ResultSet results = null;
         IDBQuery dbQuery = getDBQuery();
-        String sql = "select DATA_LENGTH,TABLE_NAME AS `NAME`,TABLE_SCHEMA AS `Database`,TABLE_COMMENT AS COMMENT,TABLE_CATALOG AS `CATALOG`,TABLE_TYPE"
-            + " AS `TYPE`,ENGINE AS `ENGINE`,CREATE_OPTIONS AS `OPTIONS`,TABLE_ROWS AS `ROWS`,CREATE_TIME,UPDATE_TIME from information_schema.tables WHERE TABLE_TYPE='BASE TABLE'";
+        String sql =
+                "select DATA_LENGTH,TABLE_NAME AS `NAME`,TABLE_SCHEMA AS `Database`,TABLE_COMMENT AS COMMENT,TABLE_CATALOG AS `CATALOG`,TABLE_TYPE"
+                        + " AS `TYPE`,ENGINE AS `ENGINE`,CREATE_OPTIONS AS `OPTIONS`,TABLE_ROWS AS `ROWS`,CREATE_TIME,UPDATE_TIME from information_schema.tables WHERE TABLE_TYPE='BASE TABLE'";
         List<Map<String, String>> schemas = null;
         try {
             preparedStatement = conn.get().prepareStatement(sql);
@@ -706,46 +713,59 @@ public abstract class AbstractJdbcDriver extends AbstractDriver {
             String tableName = split[1];
             // 匹配对应的表
             List<Map<String, String>> mapList = schemaList.stream()
-                // 过滤不匹配的表
-                .filter(x -> contains(database, x.get(dbQuery.schemaName())) && contains(tableName, x.get(dbQuery.tableName()))).collect(Collectors.toList());
+                    // 过滤不匹配的表
+                    .filter(x -> contains(database, x.get(dbQuery.schemaName()))
+                            && contains(tableName, x.get(dbQuery.tableName())))
+                    .collect(Collectors.toList());
             List<Table> tableList = mapList.stream()
-                // 去重
-                .collect(Collectors.collectingAndThen(Collectors.toCollection(
-                    () -> new TreeSet<>(Comparator.comparing(x -> getReValue(x.get(dbQuery.schemaName()), splitConfig) + "." + getReValue(x.get(dbQuery.tableName()), splitConfig)))), ArrayList::new))
-                .stream().map(x -> {
-                    Table tableInfo = new Table();
-                    tableInfo.setName(getReValue(x.get(dbQuery.tableName()), splitConfig));
-                    tableInfo.setComment(x.get(dbQuery.tableComment()));
-                    tableInfo.setSchema(getReValue(x.get(dbQuery.schemaName()), splitConfig));
-                    tableInfo.setType(x.get(dbQuery.tableType()));
-                    tableInfo.setCatalog(x.get(dbQuery.catalogName()));
-                    tableInfo.setEngine(x.get(dbQuery.engine()));
-                    tableInfo.setOptions(x.get(dbQuery.options()));
-                    tableInfo.setRows(Long.valueOf(x.get(dbQuery.rows())));
-                    try {
-                        tableInfo.setCreateTime(SimpleDateFormat.getDateInstance().parse(x.get(dbQuery.createTime())));
-                        String updateTime = x.get(dbQuery.updateTime());
-                        if (Asserts.isNotNullString(updateTime)) {
-                            tableInfo.setUpdateTime(SimpleDateFormat.getDateInstance().parse(updateTime));
+                    // 去重
+                    .collect(Collectors.collectingAndThen(Collectors.toCollection(
+                            () -> new TreeSet<>(
+                                    Comparator.comparing(x -> getReValue(x.get(dbQuery.schemaName()), splitConfig) + "."
+                                            + getReValue(x.get(dbQuery.tableName()), splitConfig)))),
+                            ArrayList::new))
+                    .stream().map(x -> {
+                        Table tableInfo = new Table();
+                        tableInfo.setName(getReValue(x.get(dbQuery.tableName()), splitConfig));
+                        tableInfo.setComment(x.get(dbQuery.tableComment()));
+                        tableInfo.setSchema(getReValue(x.get(dbQuery.schemaName()), splitConfig));
+                        tableInfo.setType(x.get(dbQuery.tableType()));
+                        tableInfo.setCatalog(x.get(dbQuery.catalogName()));
+                        tableInfo.setEngine(x.get(dbQuery.engine()));
+                        tableInfo.setOptions(x.get(dbQuery.options()));
+                        tableInfo.setRows(Long.valueOf(x.get(dbQuery.rows())));
+                        try {
+                            tableInfo.setCreateTime(
+                                    SimpleDateFormat.getDateInstance().parse(x.get(dbQuery.createTime())));
+                            String updateTime = x.get(dbQuery.updateTime());
+                            if (Asserts.isNotNullString(updateTime)) {
+                                tableInfo.setUpdateTime(SimpleDateFormat.getDateInstance().parse(updateTime));
+                            }
+                        } catch (ParseException ignored) {
+                            logger.warn("set date fail");
+
                         }
-                    } catch (ParseException ignored) {
-                        logger.warn("set date fail");
+                        TableType tableType = TableType.type(isSplit(x.get(dbQuery.schemaName()), splitConfig),
+                                isSplit(x.get(dbQuery.tableName()), splitConfig));
+                        tableInfo.setTableType(tableType);
 
-                    }
-                    TableType tableType = TableType.type(isSplit(x.get(dbQuery.schemaName()), splitConfig), isSplit(x.get(dbQuery.tableName()), splitConfig));
-                    tableInfo.setTableType(tableType);
-
-                    if (tableType != TableType.SINGLE_DATABASE_AND_TABLE) {
-                        String currentSchemaName = getReValue(x.get(dbQuery.schemaName()), splitConfig) + "." + getReValue(x.get(dbQuery.tableName()), splitConfig);
-                        List<String> schemaTableNameList =
-                            mapList.stream().filter(y -> (getReValue(y.get(dbQuery.schemaName()), splitConfig) + "." + getReValue(y.get(dbQuery.tableName()), splitConfig)).equals(currentSchemaName))
-                                .map(y -> y.get(dbQuery.schemaName()) + "." + y.get(dbQuery.tableName())).collect(Collectors.toList());
-                        tableInfo.setSchemaTableNameList(schemaTableNameList);
-                    } else {
-                        tableInfo.setSchemaTableNameList(Collections.singletonList(x.get(dbQuery.schemaName()) + "." + x.get(dbQuery.tableName())));
-                    }
-                    return tableInfo;
-                }).collect(Collectors.toList());
+                        if (tableType != TableType.SINGLE_DATABASE_AND_TABLE) {
+                            String currentSchemaName = getReValue(x.get(dbQuery.schemaName()), splitConfig) + "."
+                                    + getReValue(x.get(dbQuery.tableName()), splitConfig);
+                            List<String> schemaTableNameList =
+                                    mapList.stream()
+                                            .filter(y -> (getReValue(y.get(dbQuery.schemaName()), splitConfig) + "."
+                                                    + getReValue(y.get(dbQuery.tableName()), splitConfig))
+                                                            .equals(currentSchemaName))
+                                            .map(y -> y.get(dbQuery.schemaName()) + "." + y.get(dbQuery.tableName()))
+                                            .collect(Collectors.toList());
+                            tableInfo.setSchemaTableNameList(schemaTableNameList);
+                        } else {
+                            tableInfo.setSchemaTableNameList(Collections
+                                    .singletonList(x.get(dbQuery.schemaName()) + "." + x.get(dbQuery.tableName())));
+                        }
+                        return tableInfo;
+                    }).collect(Collectors.toList());
             set.addAll(tableList);
 
         }

--- a/dlink-metadata/dlink-metadata-base/src/main/java/com/dlink/metadata/driver/AbstractJdbcDriver.java
+++ b/dlink-metadata/dlink-metadata-base/src/main/java/com/dlink/metadata/driver/AbstractJdbcDriver.java
@@ -314,7 +314,17 @@ public abstract class AbstractJdbcDriver extends AbstractDriver {
                 }
                 field.setName(columnName);
                 if (columnList.contains(dbQuery.columnType())) {
-                    field.setType(results.getString(dbQuery.columnType()));
+                    String columnType = results.getString(dbQuery.columnType());
+                    if (columnType.contains("(")) {
+                        String type = columnType.replaceAll("\\(.*\\)", "");
+                        if(!columnType.contains(",")){
+                            Integer length = Integer.valueOf(columnType.replaceAll("\\D", ""));
+                            field.setLength(length);
+                        }
+                        field.setType(type);
+                    }else {
+                        field.setType(columnType);
+                    }
                 }
                 if (columnList.contains(dbQuery.columnComment()) && Asserts.isNotNull(results.getString(dbQuery.columnComment()))) {
                     String columnComment = results.getString(dbQuery.columnComment()).replaceAll("\"|'", "");

--- a/dlink-metadata/dlink-metadata-base/src/main/java/com/dlink/metadata/driver/AbstractJdbcDriver.java
+++ b/dlink-metadata/dlink-metadata-base/src/main/java/com/dlink/metadata/driver/AbstractJdbcDriver.java
@@ -320,6 +320,9 @@ public abstract class AbstractJdbcDriver extends AbstractDriver {
                         if(!columnType.contains(",")){
                             Integer length = Integer.valueOf(columnType.replaceAll("\\D", ""));
                             field.setLength(length);
+                        }else {
+                            // 例如浮点类型的长度和精度是一样的，decimal(10,2)
+                            field.setLength(results.getInt(dbQuery.precision()));
                         }
                         field.setType(type);
                     }else {

--- a/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/driver/MySqlDriver.java
+++ b/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/driver/MySqlDriver.java
@@ -82,18 +82,18 @@ public class MySqlDriver extends AbstractJdbcDriver {
         for (int i = 0; i < table.getColumns().size(); i++) {
             Column column = table.getColumns().get(i);
             sb.append("  `")
-                .append(column.getName()).append("`  ")
-                .append(column.getType()).append("  ");
-            //todo tmp process for varchar
-            if (column.getType().equals("varchar")) {
-                sb.append("(255)");
-            }
-            if (column.getPrecision() > 0) {
-                sb.append("(").append(column.getPrecision());
-                if (column.getScale() > 0) {
-                    sb.append(",").append(column.getScale());
+                    .append(column.getName()).append("`  ")
+                    .append(column.getType());
+            if(null != column.getLength()){
+                sb.append("(").append(column.getLength()).append(")");
+            } else {
+                if(column.getPrecision() > 0){
+                    sb.append("(").append(column.getPrecision());
+                    if (column.getScale() > 0) {
+                        sb.append(",").append(column.getScale());
+                    }
+                    sb.append(")");
                 }
-                sb.append(")");
             }
             if (Asserts.isNotNull(column.getCharacterSet())) {
                 sb.append(" CHARACTER SET ").append(column.getCharacterSet());
@@ -139,6 +139,7 @@ public class MySqlDriver extends AbstractJdbcDriver {
             sb.append(" COMMENT='").append(table.getComment()).append("'");
         }
         sb.append(";");
+        sb.toString();
         logger.info("Auto generateCreateTableSql {}", sb);
         return sb.toString();
     }

--- a/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/driver/MySqlDriver.java
+++ b/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/driver/MySqlDriver.java
@@ -85,12 +85,12 @@ public class MySqlDriver extends AbstractJdbcDriver {
                     .append(column.getName()).append("`  ")
                     .append(column.getType());
             // 处理浮点类型
-            if(column.getPrecision() > 0 && column.getScale() > 0){
+            if (column.getPrecision() > 0 && column.getScale() > 0) {
                 sb.append("(")
                         .append(column.getLength())
                         .append(",").append(column.getScale())
                         .append(")");
-            } else if(null != column.getLength()) { // 处理字符串类型和数值型
+            } else if (null != column.getLength()) { // 处理字符串类型和数值型
                 sb.append("(").append(column.getLength()).append(")");
             }
             if (Asserts.isNotNull(column.getCharacterSet())) {
@@ -137,7 +137,6 @@ public class MySqlDriver extends AbstractJdbcDriver {
             sb.append(" COMMENT='").append(table.getComment()).append("'");
         }
         sb.append(";");
-        sb.toString();
         logger.info("Auto generateCreateTableSql {}", sb);
         return sb.toString();
     }

--- a/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/driver/MySqlDriver.java
+++ b/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/driver/MySqlDriver.java
@@ -84,16 +84,14 @@ public class MySqlDriver extends AbstractJdbcDriver {
             sb.append("  `")
                     .append(column.getName()).append("`  ")
                     .append(column.getType());
-            if(null != column.getLength()){
+            // 处理浮点类型
+            if(column.getPrecision() > 0 && column.getScale() > 0){
+                sb.append("(")
+                        .append(column.getLength())
+                        .append(",").append(column.getScale())
+                        .append(")");
+            } else if(null != column.getLength()) { // 处理字符串类型和数值型
                 sb.append("(").append(column.getLength()).append(")");
-            } else {
-                if(column.getPrecision() > 0){
-                    sb.append("(").append(column.getPrecision());
-                    if (column.getScale() > 0) {
-                        sb.append(",").append(column.getScale());
-                    }
-                    sb.append(")");
-                }
             }
             if (Asserts.isNotNull(column.getCharacterSet())) {
                 sb.append(" CHARACTER SET ").append(column.getCharacterSet());

--- a/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/query/MySqlQuery.java
+++ b/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/query/MySqlQuery.java
@@ -42,7 +42,7 @@ public class MySqlQuery extends AbstractDBQuery {
 
     @Override
     public String columnsSql(String schemaName, String tableName) {
-        return "select COLUMN_NAME,DATA_TYPE,COLUMN_COMMENT,COLUMN_KEY,EXTRA AS AUTO_INCREMENT"
+        return "select COLUMN_NAME,COLUMN_TYPE,COLUMN_COMMENT,COLUMN_KEY,EXTRA AS AUTO_INCREMENT"
                 + ",COLUMN_DEFAULT,IS_NULLABLE,NUMERIC_PRECISION,NUMERIC_SCALE,CHARACTER_SET_NAME"
                 + ",COLLATION_NAME,ORDINAL_POSITION from INFORMATION_SCHEMA.COLUMNS "
                 + "where TABLE_SCHEMA = '" + schemaName + "' and TABLE_NAME = '" + tableName + "' "
@@ -54,4 +54,8 @@ public class MySqlQuery extends AbstractDBQuery {
         return "Database";
     }
 
+    @Override
+    public String columnType() {
+        return "COLUMN_TYPE";
+    }
 }


### PR DESCRIPTION
## Purpose of the pull request
Improve the automatic creation of MySQL tables. The length of strings in the previously implemented automatic creation tables is set to varchar (255). The data length of the current implementation scheme is consistent with the original table.
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dlink-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
