### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/dlink-app/dlink-app-1.11/pom.xml
+++ b/dlink-app/dlink-app-1.11/pom.xml
@@ -45,7 +45,7 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <!--            <scope>provided</scope>-->
-            <version>8.0.21</version>
+            <version>8.0.28</version>
         </dependency>
         <dependency>
             <groupId>com.dlink</groupId>

--- a/dlink-app/dlink-app-1.12/pom.xml
+++ b/dlink-app/dlink-app-1.12/pom.xml
@@ -45,7 +45,7 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <!--            <scope>provided</scope>-->
-            <version>8.0.21</version>
+            <version>8.0.28</version>
         </dependency>
         <dependency>
             <groupId>com.dlink</groupId>

--- a/dlink-app/dlink-app-1.13/pom.xml
+++ b/dlink-app/dlink-app-1.13/pom.xml
@@ -45,7 +45,7 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <!--            <scope>provided</scope>-->
-            <version>8.0.21</version>
+            <version>8.0.28</version>
         </dependency>
         <dependency>
             <groupId>com.dlink</groupId>

--- a/dlink-app/dlink-app-1.14/pom.xml
+++ b/dlink-app/dlink-app-1.14/pom.xml
@@ -45,7 +45,7 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <!--            <scope>provided</scope>-->
-            <version>8.0.21</version>
+            <version>8.0.28</version>
         </dependency>
         <dependency>
             <groupId>com.dlink</groupId>

--- a/dlink-app/dlink-app-1.15/pom.xml
+++ b/dlink-app/dlink-app-1.15/pom.xml
@@ -45,7 +45,7 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <!--            <scope>provided</scope>-->
-            <version>8.0.21</version>
+            <version>8.0.28</version>
         </dependency>
         <dependency>
             <groupId>com.dlink</groupId>

--- a/dlink-app/dlink-app-base/pom.xml
+++ b/dlink-app/dlink-app-base/pom.xml
@@ -38,7 +38,7 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <!--            <scope>provided</scope>-->
-            <version>8.0.21</version>
+            <version>8.0.28</version>
         </dependency>
         <dependency>
             <groupId>com.dlink</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in mysql:mysql-connector-java 8.0.21
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)


### What did I do？
Upgrade mysql:mysql-connector-java from 8.0.21 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS