### PR TITLE
CDCSOURCE automatically creates MySQL tables to handle double quotes

### DIFF
--- a/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/driver/MySqlDriver.java
+++ b/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/driver/MySqlDriver.java
@@ -93,14 +93,12 @@ public class MySqlDriver extends AbstractJdbcDriver {
             } else if (null != column.getLength()) { // 处理字符串类型和数值型
                 sb.append("(").append(column.getLength()).append(")");
             }
-            if (Asserts.isNotNull(column.getCharacterSet())) {
-                sb.append(" CHARACTER SET ").append(column.getCharacterSet());
-            }
-            if (Asserts.isNotNull(column.getCollation())) {
-                sb.append(" COLLATE ").append(column.getCollation());
-            }
             if (Asserts.isNotNull(column.getDefaultValue())) {
-                sb.append(" DEFAULT ").append(column.getDefaultValue());
+                if ("".equals(column.getDefaultValue())) {
+                    sb.append(" DEFAULT ").append("\"\"");
+                } else {
+                    sb.append(" DEFAULT ").append(column.getDefaultValue());
+                }
             } else {
                 if (!column.isNullable()) {
                     sb.append(" NOT ");


### PR DESCRIPTION
## Purpose of the pull request
CDCSOURCE automatically creates MySQL tables to handle double quotes
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dlink-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
