### PR TITLE
Fix v0.6.7 bug695 直接使用/openapi/executeSql提交的任务运维中心无法管理

### DIFF
--- a/dlink-admin/src/main/java/com/dlink/dto/APIExecuteSqlDTO.java
+++ b/dlink-admin/src/main/java/com/dlink/dto/APIExecuteSqlDTO.java
@@ -43,6 +43,7 @@ public class APIExecuteSqlDTO extends AbstractStatementDTO {
     private boolean useChangeLog = false;
     private boolean useAutoCancel = false;
     private boolean useStatementSet = false;
+    private Integer clusterId;
     private String address;
     private String jobName;
     private Integer maxRowNum = 100;
@@ -58,7 +59,7 @@ public class APIExecuteSqlDTO extends AbstractStatementDTO {
             savePointStrategy = 3;
         }
         return new JobConfig(
-                type, useResult, useChangeLog, useChangeLog, false, null, true, address, jobName,
+                type, clusterId, useResult, useChangeLog, useChangeLog, false, null, true, address, jobName,
                 isFragment(), useStatementSet, maxRowNum, checkPoint, parallelism, savePointStrategy,
                 savePointPath, configuration, gatewayConfig);
     }

--- a/dlink-core/src/main/java/com/dlink/job/JobConfig.java
+++ b/dlink-core/src/main/java/com/dlink/job/JobConfig.java
@@ -115,11 +115,12 @@ public class JobConfig {
         this.config = config;
     }
 
-    public JobConfig(String type, boolean useResult, boolean useChangeLog, boolean useAutoCancel, boolean useSession, String session, boolean useRemote, String address,
+    public JobConfig(String type, Integer clusterId, boolean useResult, boolean useChangeLog, boolean useAutoCancel, boolean useSession, String session, boolean useRemote, String address,
                      String jobName, boolean useSqlFragment,
                      boolean useStatementSet, Integer maxRowNum, Integer checkpoint, Integer parallelism,
                      Integer savePointStrategyValue, String savePointPath, Map<String, String> config, GatewayConfig gatewayConfig) {
         this.type = type;
+        this.clusterId = clusterId;
         this.useResult = useResult;
         this.useChangeLog = useChangeLog;
         this.useAutoCancel = useAutoCancel;


### PR DESCRIPTION
## Purpose of the pull request

I want to fix the bug #695 by add a param in com.dlink.dto.APIExecuteSqlDTO

## Brief change log
com.dlink.dto.APIExecuteSqlDTO  add a param  clusterId 
modify the constructed method in com.dlink.job.JobConfig

## Verify this pull request
post http://ip:port/openapi/executeSql
{
  "type":"yarn-session",
  "address":"ip:port",
  "clusterId": 50, // I add
  "statement":"CREATE TABLE Orders (\r\n    order_number INT,\r\n    price        DECIMAL(32,2),\r\n    order_time   TIMESTAMP(3)\r\n) WITH (\r\n  'connector' = 'datagen',\r\n  'rows-per-second' = '1',\r\n  'fields.order_number.kind' = 'sequence',\r\n  'fields.order_number.start' = '1',\r\n  'fields.order_number.end' = '1000'\r\n);\r\nCREATE TABLE pt (\r\nordertotal INT,\r\nnumtotal INT\r\n) WITH (\r\n 'connector' = 'print'\r\n);\r\ninsert into pt select 1 as ordertotal ,sum(order_number)*2 as numtotal from Orders",
  "useResult":false,
  "useStatementSet":false,
  "useChangeLog":false,
  "useAutoCancel":false,
  "fragment":false,
  "maxRowNum":100,
  "checkPoint":0,
  "parallelism":1,
  "jobName":"openapitest-1206",
  "configuration":{
    "table.exec.resource.default-parallelism":2
  }
}
![image](https://user-images.githubusercontent.com/72123724/205878438-04ab51b0-56de-4767-bcaa-58242a6bebe4.png)
I got a running job
