### PR TITLE
[Fix][web] studio tree right-click menu covered up at the edge

### DIFF
--- a/dlink-web/src/components/Studio/StudioTree/index.tsx
+++ b/dlink-web/src/components/Studio/StudioTree/index.tsx
@@ -445,7 +445,7 @@ const StudioTree: React.FC<StudioTreeProps> = (props) => {
   const getNodeTreeRightClickMenu = () => {
     const {pageX, pageY} = {...rightClickNodeTreeItem};
     const tmpStyle: any = {
-      position: 'absolute',
+      position: 'fixed',
       left: pageX,
       top: pageY,
     };
@@ -509,12 +509,10 @@ const StudioTree: React.FC<StudioTreeProps> = (props) => {
   };
 
   const handleContextMenu = (e: any) => {
-    let position = e.event.currentTarget.getBoundingClientRect();
-    let scrollTop = document.documentElement.scrollTop;
     setRightClickNode(e.node);
     setRightClickNodeTreeItem({
-      pageX: e.event.pageX - 40,
-      pageY: position.y + sref.current.getScrollTop() + scrollTop - 145 - position.height,
+      pageX: e.event.pageX,
+      pageY: e.event.pageY,
       id: e.node.id,
       categoryName: e.node.name
     });


### PR DESCRIPTION
## Purpose of the pull request
#1394 
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
set right-click menu position to `fixed` in dlink-web/src/components/Studio/StudioTree/index.tsx
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dlink-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
