### PR TITLE
Fix: 修复血缘计算导致CPU飙升服务宕机的问题 #1453

### DIFF
--- a/dlink-core/src/main/java/com/dlink/explainer/Explainer.java
+++ b/dlink-core/src/main/java/com/dlink/explainer/Explainer.java
@@ -509,7 +509,7 @@ public class Explainer {
                 SqlType operationType = Operations.getOperationType(sql);
                 if (operationType.equals(SqlType.INSERT)) {
                     lineageRelList.addAll(executor.getLineage(sql));
-                } else {
+                } else if (!operationType.equals(SqlType.SELECT)) {
                     executor.executeSql(sql);
                 }
             } catch (Exception e) {


### PR DESCRIPTION
FlinkSQL字段血缘的实现原理：
1. 对输入SQL进行Parse、Validate、Convert，生成关系表达式RelNode树
2. 在优化阶段，只生成到Optimized Logical Plan即可，而非原本的Optimized Physical Plan。
3.针对上步骤优化生成的逻辑RelNode，调用RelMetadataQuery的getColumnOrigins(RelNode rel,int column)查询原始字段信息。然后构造血缘关系，并返回结果。

通过Flink的源码及我们项目的血缘实现方案可以发现，对于SELECT类型的语句，会提交到Runtime层去执行，导致了服务中CPU占用率特别的高，本身目前SELECT语句也是不参与血缘计算的，所以解决的方法是在提交Flink SQL时，排除掉SELECT类型的语句
