### PR TITLE
fix(sec): upgrade org.apache.httpcomponents:httpclient to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <!--<flyway.version>6.4.4</flyway.version>-->
         <sa-token.version>1.31.0</sa-token.version>
         <commons-lang3.version>3.3.2</commons-lang3.version>
-        <httpclient.version>4.4.1</httpclient.version>
+        <httpclient.version>4.5.13</httpclient.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
         <maven.resource.version>3.2.0</maven.resource.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.httpcomponents:httpclient 4.4.1
- [CVE-2020-13956](https://www.oscs1024.com/hd/CVE-2020-13956)


### What did I do？
Upgrade org.apache.httpcomponents:httpclient from 4.4.1 to 4.5.13 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS