### PR TITLE
[Fix][Doc] Flink SQL SET error examples

### DIFF
--- a/docs/versioned_docs/version-0.7/flink_sql_development_guide/set_statement.md
+++ b/docs/versioned_docs/version-0.7/flink_sql_development_guide/set_statement.md
@@ -13,7 +13,7 @@ SET 语句中字符串类型的配置项和参数值可以不用半角单引号�
 ```sql
 SET key = value;
 #或者
-SET `key` = `value`;
+SET 'key' = 'value';
 ```
 
 各个版本的参数配置详见Flink开源社区:


### PR DESCRIPTION
这里半角单引号打错啦，打的重音符合，这样实际存的是 **\`value\`** 而不是 **value**

## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->
修复dinky 中文文档中 Flink SQL开发指南部分SET语句中的错误示例描述,示例上方描述是准确的，但是给的示例是错误的。
![image](https://user-images.githubusercontent.com/22070968/217132370-80c05fa8-aa7b-4db0-b813-c0f0440c7411.png)

## Brief change log
将示例中的
```sql
SET `key`=`value`;
```
中的重音符改为
```sql
SET 'key'='value'
```
半角单引号
<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request
我在flink1.13.5对应的sqlclient中做了验证
使用重音符(`)的case:
![image](https://user-images.githubusercontent.com/22070968/217132968-5d1a28b8-6066-4a86-a501-a89031107ee2.png)
使用单引号(')的case:
![image](https://user-images.githubusercontent.com/22070968/217133336-79fc4ec0-5b28-459a-8989-838a71e1b39d.png)

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
