### PR TITLE
fixed catalog cannot be deleted and alter

### DIFF
--- a/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.13/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
+++ b/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.13/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
@@ -407,7 +407,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
             dStat.setInt(1, id);
             dStat.executeUpdate();
             dStat.close();
-            String deleteDbSql = "delete from metadata_database where database_id=?";
+            String deleteDbSql = "delete from metadata_database where id=?";
             dStat = conn.prepareStatement(deleteDbSql);
             dStat.setInt(1, id);
             dStat.executeUpdate();
@@ -438,7 +438,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
             conn.setAutoCommit(false);
             // 1、名称不能改，类型不能改。只能改备注
             String updateCommentSql =
-                    "update metadata_database set description=? where  database_id=?";
+                    "update metadata_database set description=? where id=?";
             PreparedStatement uState = conn.prepareStatement(updateCommentSql);
             uState.setString(1, newDb.getComment());
             uState.setInt(2, id);

--- a/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.13/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
+++ b/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.13/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
@@ -272,7 +272,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
                     pStat.setInt(1, id);
                     ResultSet prs = pStat.executeQuery();
                     while (prs.next()) {
-                        map.put(rs.getString("key"), rs.getString("value"));
+                        map.put(prs.getString("key"), prs.getString("value"));
                     }
                 } catch (SQLException e) {
                     sqlExceptionHappened = true;

--- a/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.13/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
+++ b/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.13/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
@@ -437,8 +437,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
         try {
             conn.setAutoCommit(false);
             // 1、名称不能改，类型不能改。只能改备注
-            String updateCommentSql =
-                    "update metadata_database set description=? where id=?";
+            String updateCommentSql = "update metadata_database set description=? where id=?";
             PreparedStatement uState = conn.prepareStatement(updateCommentSql);
             uState.setString(1, newDb.getComment());
             uState.setInt(2, id);

--- a/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.14/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
+++ b/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.14/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
@@ -277,7 +277,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
                     pStat.setInt(1, id);
                     ResultSet prs = pStat.executeQuery();
                     while (prs.next()) {
-                        map.put(rs.getString("key"), rs.getString("value"));
+                        map.put(prs.getString("key"), prs.getString("value"));
                     }
                 } catch (SQLException e) {
                     sqlExceptionHappened = true;

--- a/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.14/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
+++ b/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.14/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
@@ -443,8 +443,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
         try {
             conn.setAutoCommit(false);
             // 1、名称不能改，类型不能改。只能改备注
-            String updateCommentSql =
-                    "update metadata_database set description=? where id=?";
+            String updateCommentSql = "update metadata_database set description=? where id=?";
             PreparedStatement uState = conn.prepareStatement(updateCommentSql);
             uState.setString(1, newDb.getComment());
             uState.setInt(2, id);

--- a/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.14/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
+++ b/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.14/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
@@ -413,7 +413,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
             dStat.setInt(1, id);
             dStat.executeUpdate();
             dStat.close();
-            String deleteDbSql = "delete from metadata_database where database_id=?";
+            String deleteDbSql = "delete from metadata_database where id=?";
             dStat = conn.prepareStatement(deleteDbSql);
             dStat.setInt(1, id);
             dStat.executeUpdate();
@@ -444,7 +444,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
             conn.setAutoCommit(false);
             // 1、名称不能改，类型不能改。只能改备注
             String updateCommentSql =
-                    "update metadata_database set description=? where  database_id=?";
+                    "update metadata_database set description=? where id=?";
             PreparedStatement uState = conn.prepareStatement(updateCommentSql);
             uState.setString(1, newDb.getComment());
             uState.setInt(2, id);

--- a/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.15/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
+++ b/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.15/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
@@ -411,7 +411,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
             dStat.setInt(1, id);
             dStat.executeUpdate();
             dStat.close();
-            String deleteDbSql = "delete from metadata_database where database_id=?";
+            String deleteDbSql = "delete from metadata_database where id=?";
             dStat = conn.prepareStatement(deleteDbSql);
             dStat.setInt(1, id);
             dStat.executeUpdate();
@@ -442,7 +442,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
             conn.setAutoCommit(false);
             // 1、名称不能改，类型不能改。只能改备注
             String updateCommentSql =
-                    "update metadata_database set description=? where  database_id=?";
+                    "update metadata_database set description=? where id=?";
             PreparedStatement uState = conn.prepareStatement(updateCommentSql);
             uState.setString(1, newDb.getComment());
             uState.setInt(2, id);

--- a/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.15/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
+++ b/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.15/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
@@ -275,7 +275,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
                     pStat.setInt(1, id);
                     ResultSet prs = pStat.executeQuery();
                     while (prs.next()) {
-                        map.put(rs.getString("key"), rs.getString("value"));
+                        map.put(prs.getString("key"), prs.getString("value"));
                     }
                 } catch (SQLException e) {
                     sqlExceptionHappened = true;

--- a/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.15/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
+++ b/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.15/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
@@ -441,8 +441,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
         try {
             conn.setAutoCommit(false);
             // 1、名称不能改，类型不能改。只能改备注
-            String updateCommentSql =
-                    "update metadata_database set description=? where id=?";
+            String updateCommentSql = "update metadata_database set description=? where id=?";
             PreparedStatement uState = conn.prepareStatement(updateCommentSql);
             uState.setString(1, newDb.getComment());
             uState.setInt(2, id);

--- a/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.16/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
+++ b/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.16/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
@@ -277,7 +277,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
                     pStat.setInt(1, id);
                     ResultSet prs = pStat.executeQuery();
                     while (prs.next()) {
-                        map.put(rs.getString("key"), rs.getString("value"));
+                        map.put(prs.getString("key"), prs.getString("value"));
                     }
                 } catch (SQLException e) {
                     sqlExceptionHappened = true;

--- a/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.16/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
+++ b/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.16/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
@@ -443,8 +443,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
         try {
             conn.setAutoCommit(false);
             // 1、名称不能改，类型不能改。只能改备注
-            String updateCommentSql =
-                    "update metadata_database set description=? where id=?";
+            String updateCommentSql = "update metadata_database set description=? where id=?";
             PreparedStatement uState = conn.prepareStatement(updateCommentSql);
             uState.setString(1, newDb.getComment());
             uState.setInt(2, id);

--- a/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.16/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
+++ b/dinky-catalog/dinky-catalog-mysql/dinky-catalog-mysql-1.16/src/main/java/org/dinky/flink/catalog/DinkyMysqlCatalog.java
@@ -413,7 +413,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
             dStat.setInt(1, id);
             dStat.executeUpdate();
             dStat.close();
-            String deleteDbSql = "delete from metadata_database where database_id=?";
+            String deleteDbSql = "delete from metadata_database where id=?";
             dStat = conn.prepareStatement(deleteDbSql);
             dStat.setInt(1, id);
             dStat.executeUpdate();
@@ -444,7 +444,7 @@ public class DinkyMysqlCatalog extends AbstractCatalog {
             conn.setAutoCommit(false);
             // 1、名称不能改，类型不能改。只能改备注
             String updateCommentSql =
-                    "update metadata_database set description=? where  database_id=?";
+                    "update metadata_database set description=? where id=?";
             PreparedStatement uState = conn.prepareStatement(updateCommentSql);
             uState.setString(1, newDb.getComment());
             uState.setInt(2, id);


### PR DESCRIPTION
## Purpose of the pull request

https://github.com/DataLinkDC/dinky/issues/1571 fixed catalog cannot be deleted and alter


## Brief change log

  - *edit dinky-catalog-mysql*

## Verify this pull request

1. start `sql-client.sh`
2. execute sql
```sql
-- 创建catalog
CREATE CATALOG my_catalog with(
    'type' = 'dinky_mysql', 
    'username' = 'dinky', 
    'password' = '****', 
    'url' = 'jdbc:mysql://127.0.0.1:3306/dinky?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&useSSL=false&zeroDateTimeBehavior=convertToNull&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true' 
);

-- 创建待测试的database
CREATE DATABASE IF NOT EXISTS my_catalog.demo_db COMMENT '这是一个示例库'
WITH (
    'hello' = 'world'
);
USE CATALOG my_catalog;
-- 测试查询
SHOW DATABASES;
-- 测试修改
ALTER DATABASE my_catalog.demo_db SET ('aa' = '1');
-- 测试删除
DROP DATABASE my_catalog.demo_db CASCADE;
```
