### PR TITLE
[Fix-1697][doc]fix add k8s app cluster failed (#1697)

### DIFF
--- a/script/bin/auto.sh
+++ b/script/bin/auto.sh
@@ -6,7 +6,7 @@ JAR_NAME="dlink-admin"
 
 # Use FLINK_HOME:
 # CLASS_PATH="./lib/*:./plugins/*:./plugins/flink${FLINK_VERSION}/*:$FLINK_HOME/lib/*"
-CLASS_PATH="./lib/*:./plugins/*:./plugins/flink${FLINK_VERSION}/*"
+CLASS_PATH="./lib/*:config:html:./plugins/*:./plugins/flink${FLINK_VERSION}/*"
 
 PID_FILE="dinky.pid"
 


### PR DESCRIPTION
[Fix-1697][doc]fix add k8s app cluster failed (#1697)

## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
