### PR TITLE
k8s operator支持

### DIFF
--- a/dinky-admin/pom.xml
+++ b/dinky-admin/pom.xml
@@ -192,6 +192,12 @@
         <dependency>
             <groupId>org.dinky</groupId>
             <artifactId>dinky-gateway</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>

--- a/dinky-admin/src/main/java/org/dinky/service/impl/ClusterConfigurationServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/ClusterConfigurationServiceImpl.java
@@ -19,6 +19,8 @@
 
 package org.dinky.service.impl;
 
+import static org.dinky.gateway.config.GatewayConfig.FLINK_VERSION;
+
 import org.dinky.config.Docker;
 import org.dinky.db.service.impl.SuperServiceImpl;
 import org.dinky.gateway.GatewayType;
@@ -30,6 +32,7 @@ import org.dinky.job.JobManager;
 import org.dinky.mapper.ClusterConfigurationMapper;
 import org.dinky.model.ClusterConfiguration;
 import org.dinky.model.FlinkClusterConfiguration;
+import org.dinky.model.FlinkClusterConfiguration.Type;
 import org.dinky.service.ClusterConfigurationService;
 import org.dinky.utils.DockerClientUtils;
 
@@ -131,6 +134,10 @@ public class ClusterConfigurationServiceImpl
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
+        } else if (config.getType() == Type.KubernetesOperator) {
+            gatewayConfig.setType(GatewayType.KUBERNETES_APPLICATION_OPERATOR);
+            config.getKubernetesConfig().put(FLINK_VERSION, config.getFlinkVersion());
+            flinkConfig.setFlinkKubetnetsConfig(config.getKubernetesConfig());
         }
 
         return JobManager.testGateway(gatewayConfig);

--- a/dinky-admin/src/main/java/org/dinky/service/impl/TaskServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/TaskServiceImpl.java
@@ -1425,7 +1425,8 @@ public class TaskServiceImpl extends SuperServiceImpl<TaskMapper, Task> implemen
             jobConfig.buildGatewayConfig(clusterConfig);
             jobConfig.getGatewayConfig().setType(GatewayType.get(jobInstance.getType()));
             jobConfig.getGatewayConfig().getFlinkConfig().setJobName(jobInstance.getName());
-            Gateway.build(jobConfig.getGatewayConfig()).onJobFinishCallback(jobInstance.getStatus());
+            Gateway.build(jobConfig.getGatewayConfig())
+                    .onJobFinishCallback(jobInstance.getStatus());
         }
 
         if (!JobLifeCycle.ONLINE.equalsValue(jobInstance.getStep())) {

--- a/dinky-admin/src/main/java/org/dinky/service/impl/TaskServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/TaskServiceImpl.java
@@ -1055,8 +1055,7 @@ public class TaskServiceImpl extends SuperServiceImpl<TaskMapper, Task> implemen
                         clusterConfigurationService.getClusterConfigById(
                                 history.getClusterConfigurationId());
                 jobInfoDetail.setClusterConfiguration(clusterConfigById);
-                Task task = getById(jobInstance.getTaskId());
-                jobInfoDetail.getInstance().setType(task.getType());
+                jobInfoDetail.getInstance().setType(history.getType());
             }
             jobInfoDetail.setHistory(history);
             jobInfoDetail.setJobHistory(jobHistoryService.getJobHistory(id));
@@ -1415,7 +1414,6 @@ public class TaskServiceImpl extends SuperServiceImpl<TaskMapper, Task> implemen
         Integer jobInstanceId = jobInstance.getId();
         // 获取任务历史信息
         JobHistory jobHistory = jobHistoryService.getJobHistory(jobInstanceId);
-
         // some job need do something on Done, example flink-kubernets-operator
         if (GatewayType.isDeployCluster(jobInstance.getType())) {
             JobConfig jobConfig = new JobConfig();
@@ -1427,7 +1425,7 @@ public class TaskServiceImpl extends SuperServiceImpl<TaskMapper, Task> implemen
             jobConfig.buildGatewayConfig(clusterConfig);
             jobConfig.getGatewayConfig().setType(GatewayType.get(jobInstance.getType()));
             jobConfig.getGatewayConfig().getFlinkConfig().setJobName(jobInstance.getName());
-            Gateway.build(jobConfig.getGatewayConfig()).handleJobDone(jobInstance.getStatus());
+            Gateway.build(jobConfig.getGatewayConfig()).onJobFinishCallback(jobInstance.getStatus());
         }
 
         if (!JobLifeCycle.ONLINE.equalsValue(jobInstance.getStep())) {

--- a/dinky-admin/src/main/java/org/dinky/service/impl/TaskServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/TaskServiceImpl.java
@@ -1409,10 +1409,6 @@ public class TaskServiceImpl extends SuperServiceImpl<TaskMapper, Task> implemen
         Task updateTask = new Task();
         updateTask.setId(jobInstance.getTaskId());
         updateTask.setJobInstanceId(0);
-        if (!JobLifeCycle.ONLINE.equalsValue(jobInstance.getStep())) {
-            updateById(updateTask);
-            return;
-        }
 
         Integer jobInstanceId = jobInstance.getId();
         // 获取任务历史信息

--- a/dinky-admin/src/main/java/org/dinky/service/impl/TaskServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/TaskServiceImpl.java
@@ -965,9 +965,10 @@ public class TaskServiceImpl extends SuperServiceImpl<TaskMapper, Task> implemen
                     clusterService.buildEnvironmentAddress(
                             config.isUseRemote(), task.getClusterId()));
         } else if (Dialect.KUBERNETES_APPLICATION.equalsVal(task.getDialect())
-                        // support custom K8s app submit, rather than clusterConfiguration
-                        && GatewayType.KUBERNETES_APPLICATION.equalsValue(config.getType())
-                || GatewayType.KUBERNETES_APPLICATION_OPERATOR.equalsValue(config.getType())) {
+                // support custom K8s app submit, rather than clusterConfiguration
+                && (GatewayType.KUBERNETES_APPLICATION.equalsValue(config.getType())
+                        || GatewayType.KUBERNETES_APPLICATION_OPERATOR.equalsValue(
+                                config.getType()))) {
             Map<String, Object> taskConfig =
                     JSONUtil.toMap(task.getStatement(), String.class, Object.class);
             Map<String, Object> clusterConfiguration =
@@ -980,7 +981,8 @@ public class TaskServiceImpl extends SuperServiceImpl<TaskMapper, Task> implemen
                     clusterConfigurationService.getGatewayConfig(task.getClusterConfigurationId());
             // submit application type with clusterConfiguration
             if (GatewayType.YARN_APPLICATION.equalsValue(config.getType())
-                    || GatewayType.KUBERNETES_APPLICATION.equalsValue(config.getType())) {
+                    || GatewayType.KUBERNETES_APPLICATION.equalsValue(config.getType())
+                    || GatewayType.KUBERNETES_APPLICATION_OPERATOR.equalsValue(config.getType())) {
                 if (isJarTask) {
                     Jar jar = jarService.getById(task.getJarId());
                     Assert.check(jar);

--- a/dinky-core/src/main/java/org/dinky/job/JobManager.java
+++ b/dinky-core/src/main/java/org/dinky/job/JobManager.java
@@ -211,7 +211,8 @@ public class JobManager {
     public static boolean useGateway(String type) {
         return (GatewayType.YARN_PER_JOB.equalsValue(type)
                 || GatewayType.YARN_APPLICATION.equalsValue(type)
-                || GatewayType.KUBERNETES_APPLICATION.equalsValue(type));
+                || GatewayType.KUBERNETES_APPLICATION.equalsValue(type)
+                || GatewayType.KUBERNETES_APPLICATION_OPERATOR.equalsValue(type));
     }
 
     private Executor createExecutor() {

--- a/dinky-gateway/pom.xml
+++ b/dinky-gateway/pom.xml
@@ -31,6 +31,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <version>5.12.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.dinky</groupId>
             <artifactId>dinky-common</artifactId>
         </dependency>
@@ -135,6 +140,94 @@ for k8s commit tasks-->
             <artifactId>dinky-process</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-dinky</id>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <include>io.fabric8:kubernetes-client</include>
+                                    <include>io.fabric8:kubernetes-model-*</include>
+                                    <include>io.fabric8:zjsonpatch</include>
+
+                                    <!-- Shade all the dependencies of kubernetes client  -->
+                                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                                    <include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</include>
+                                    <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
+                                    <include>com.squareup.okhttp3:*</include>
+                                    <include>com.squareup.okio:okio</include>
+                                    <include>org.yaml:*</include>
+                                    <include>dk.brics.automaton:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters combine.children="append">
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>*.aut</exclude>
+                                        <exclude>META-INF/services/*com.fasterxml*</exclude>
+                                        <exclude>META-INF/proguard/**</exclude>
+                                        <exclude>OSGI-INF/**</exclude>
+                                        <exclude>schema/**</exclude>
+                                        <exclude>*.vm</exclude>
+                                        <exclude>*.properties</exclude>
+                                        <exclude>*.xml</exclude>
+                                        <exclude>META-INF/jandex.idx</exclude>
+                                        <exclude>license.header</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>org.dinky.gateway.kubernetes.operator.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>okhttp3/internal/publicsuffix</pattern>
+                                    <shadedPattern>META-INF</shadedPattern>
+                                    <includes>
+                                        <include>**/NOTICE</include>
+                                    </includes>
+                                </relocation>
+                                <relocation>
+                                    <pattern>okhttp3</pattern>
+                                    <shadedPattern>org.dinky.gateway.kubernetes.operator.okhttp3</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>okio</pattern>
+                                    <shadedPattern>org.dinky.gateway.kubernetes.operator.okio</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.yaml</pattern>
+                                    <shadedPattern>org.dinky.gateway.kubernetes.operator.org.yaml</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>dk.brics.automaton</pattern>
+                                    <shadedPattern>org.dinky.gateway.kubernetes.operator.dk.brics.automaton</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.fabric8</pattern>
+                                    <shadedPattern>org.dinky.gateway.kubernetes.operator.io.fabric8</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/dinky-gateway/pom.xml
+++ b/dinky-gateway/pom.xml
@@ -130,6 +130,10 @@ for k8s commit tasks-->
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.dinky</groupId>
+            <artifactId>dinky-process</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/dinky-gateway/src/main/java/org/dinky/gateway/AbstractGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/AbstractGateway.java
@@ -231,4 +231,9 @@ public abstract class AbstractGateway implements Gateway {
         }
         return clusterSpecificationBuilder;
     }
+
+    @Override
+    public boolean handleJobDone(String status) {
+        return true;
+    }
 }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/AbstractGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/AbstractGateway.java
@@ -233,7 +233,7 @@ public abstract class AbstractGateway implements Gateway {
     }
 
     @Override
-    public boolean handleJobDone(String status) {
+    public boolean onJobFinishCallback(String status) {
         return true;
     }
 }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/Gateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/Gateway.java
@@ -86,5 +86,7 @@ public interface Gateway {
 
     void killCluster();
 
+    boolean handleJobDone(String status);
+
     GatewayResult deployCluster();
 }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/Gateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/Gateway.java
@@ -86,7 +86,7 @@ public interface Gateway {
 
     void killCluster();
 
-    boolean handleJobDone(String status);
+    boolean onJobFinishCallback(String status);
 
     GatewayResult deployCluster();
 }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/GatewayType.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/GatewayType.java
@@ -35,7 +35,7 @@ public enum GatewayType {
     YARN_PER_JOB("ypj", "yarn-per-job"),
     KUBERNETES_SESSION("ks", "kubernetes-session"),
     KUBERNETES_APPLICATION("ka", "kubernetes-application"),
-    KUBERNETES_APPLICATION_OPERATOR("koa", "kubernetes-application-operator");
+    KUBERNETES_APPLICATION_OPERATOR("kao", "kubernetes-application-operator");
 
     private final String value;
     private final String longValue;
@@ -103,6 +103,7 @@ public enum GatewayType {
         switch (value) {
             case "ya":
             case "ka":
+            case "kao":
                 return true;
             default:
                 return false;

--- a/dinky-gateway/src/main/java/org/dinky/gateway/GatewayType.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/GatewayType.java
@@ -34,7 +34,8 @@ public enum GatewayType {
     YARN_APPLICATION("ya", "yarn-application"),
     YARN_PER_JOB("ypj", "yarn-per-job"),
     KUBERNETES_SESSION("ks", "kubernetes-session"),
-    KUBERNETES_APPLICATION("ka", "kubernetes-application");
+    KUBERNETES_APPLICATION("ka", "kubernetes-application"),
+    KUBERNETES_APPLICATION_OPERATOR("koa", "kubernetes-application-operator");
 
     private final String value;
     private final String longValue;
@@ -80,6 +81,7 @@ public enum GatewayType {
             case YARN_APPLICATION:
             case YARN_PER_JOB:
             case KUBERNETES_APPLICATION:
+            case KUBERNETES_APPLICATION_OPERATOR:
                 return true;
             default:
                 return false;

--- a/dinky-gateway/src/main/java/org/dinky/gateway/config/FlinkConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/config/FlinkConfig.java
@@ -48,6 +48,7 @@ public class FlinkConfig {
     private SavePointType savePointType;
     private String savePoint;
     private Map<String, String> configuration = new HashMap<>();
+    private Map<String, String> FlinkKubetnetsConfig = new HashMap<>();
 
     private static final ObjectMapper mapper = new ObjectMapper();
 

--- a/dinky-gateway/src/main/java/org/dinky/gateway/config/GatewayConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/config/GatewayConfig.java
@@ -44,6 +44,7 @@ public class GatewayConfig {
 
     public static final String FLINK_CONFIG_PATH = "flinkConfigPath";
     public static final String FLINK_LIB_PATH = "flinkLibPath";
+    public static final String FLINK_VERSION = "flinkVersion";
     public static final String HADOOP_CONFIG_PATH = "hadoopConfigPath";
     public static final String USER_JAR_PATH = "userJarPath";
     public static final String USER_JAR_MAIN_APP_CLASS = "userJarMainAppClass";
@@ -87,10 +88,16 @@ public class GatewayConfig {
         }
 
         final Map<String, String> configuration = fc.getConfiguration();
+        final Map<String, String> k8sConfig = fc.getFlinkKubetnetsConfig();
+
         if (config.containsKey(KUBERNETES_CONFIG)) {
             Map<String, String> kubernetesConfig =
                     (Map<String, String>) config.get(KUBERNETES_CONFIG);
-            configuration.putAll(kubernetesConfig);
+            k8sConfig.putAll(kubernetesConfig);
+        }
+
+        if (config.containsKey(FLINK_VERSION)) {
+            k8sConfig.put(FLINK_VERSION, String.valueOf(config.get(FLINK_VERSION)));
         }
 
         // at present only k8s task have this
@@ -98,7 +105,7 @@ public class GatewayConfig {
             Map<String, Map<String, String>> taskCustomConfig =
                     (Map<String, Map<String, String>>) config.get(TASK_CUSTOM_CONFIG);
             if (taskCustomConfig.containsKey(KUBERNETES_CONFIG)) {
-                configuration.putAll(taskCustomConfig.get(KUBERNETES_CONFIG));
+                k8sConfig.putAll(taskCustomConfig.get(KUBERNETES_CONFIG));
             }
             if (taskCustomConfig.containsKey(FLINK_CONFIG)) {
                 configuration.putAll(taskCustomConfig.get(FLINK_CONFIG));
@@ -138,7 +145,7 @@ public class GatewayConfig {
                     config.get(FLINK_LIB_PATH).toString(),
                     config.get(HADOOP_CONFIG_PATH).toString());
         } else {
-            return ClusterConfig.build(config.get(FLINK_CONFIG_PATH).toString());
+            return ClusterConfig.build(String.valueOf(config.get(FLINK_CONFIG_PATH)));
         }
     }
 }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/KubernetesGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/KubernetesGateway.java
@@ -74,6 +74,9 @@ public abstract class KubernetesGateway extends AbstractGateway {
                         config.getClusterConfig().getFlinkConfigPath());
 
         final FlinkConfig flinkConfig = config.getFlinkConfig();
+        if (flinkConfig.getFlinkKubetnetsConfig() != null) {
+            flinkConfig.getConfiguration().putAll(flinkConfig.getFlinkKubetnetsConfig());
+        }
         if (Asserts.isNotNull(flinkConfig.getConfiguration())) {
             addConfigParas(flinkConfig.getConfiguration());
         }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetsOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetsOperatorGateway.java
@@ -90,7 +90,7 @@ public abstract class KubernetsOperatorGateway extends AbstractGateway {
     }
 
     @Override
-    public boolean handleJobDone(String status) {
+    public boolean onJobFinishCallback(String status) {
 
         submitConfiguration = config.getFlinkConfig().getFlinkKubetnetsConfig();
         kubernetesClient = new DefaultKubernetesClient();

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetsOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetsOperatorGateway.java
@@ -1,0 +1,266 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.gateway.kubernetes.operator;
+
+import org.dinky.assertion.Asserts;
+import org.dinky.gateway.AbstractGateway;
+import org.dinky.gateway.kubernetes.operator.api.AbstractPodSpec;
+import org.dinky.gateway.kubernetes.operator.api.AbstractPodSpec.Resource;
+import org.dinky.gateway.kubernetes.operator.api.FlinkDeployment;
+import org.dinky.gateway.kubernetes.operator.api.FlinkDeploymentSpec;
+import org.dinky.gateway.kubernetes.operator.api.JobSpec;
+import org.dinky.gateway.kubernetes.operator.api.UpgradeMode;
+import org.dinky.gateway.result.SavePointResult;
+import org.dinky.gateway.result.TestResult;
+import org.dinky.model.JobStatus;
+import org.dinky.process.context.ProcessContextHolder;
+import org.dinky.process.model.ProcessEntity;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public abstract class KubernetsOperatorGateway extends AbstractGateway {
+
+    private Map<String, String> submitConfiguration;
+    private Map<String, String> flinkConfig;
+    private FlinkDeployment flinkDeployment = new FlinkDeployment();
+    private FlinkDeploymentSpec flinkDeploymentSpec = new FlinkDeploymentSpec();
+    private KubernetesClient kubernetesClient;
+    private ProcessEntity process = ProcessContextHolder.getProcess();
+
+    private static final Logger logger = LoggerFactory.getLogger(KubernetsOperatorGateway.class);
+
+    @Override
+    protected void init() {
+        submitConfiguration = config.getFlinkConfig().getFlinkKubetnetsConfig();
+        flinkConfig = config.getFlinkConfig().getConfiguration();
+        kubernetesClient = new DefaultKubernetesClient();
+        initBase();
+        initMetadata();
+        initSpec();
+        initResource(kubernetesClient);
+        initJob();
+    }
+
+    @Override
+    public TestResult test() {
+
+        submitConfiguration = config.getFlinkConfig().getFlinkKubetnetsConfig();
+        flinkConfig = config.getFlinkConfig().getConfiguration();
+        config.getFlinkConfig().setJobName("test");
+        kubernetesClient = new DefaultKubernetesClient();
+        initBase();
+        initMetadata();
+        initSpec();
+        kubernetesClient.resource(flinkDeployment).fromServer();
+        logger.info("配置连接测试成功");
+        return TestResult.success();
+    }
+
+    @Override
+    public boolean handleJobDone(String status) {
+
+        submitConfiguration = config.getFlinkConfig().getFlinkKubetnetsConfig();
+        kubernetesClient = new DefaultKubernetesClient();
+
+        String jobName = config.getFlinkConfig().getJobName();
+        if (status.equals(JobStatus.FINISHED.getValue())) {
+            logger.info(
+                    "start handle job {} done on application mode, job status is {}, the cluster will be delete later..",
+                    jobName,
+                    status);
+            return deleteCluster();
+        }
+        return false;
+    }
+
+    public boolean deleteCluster() {
+        initMetadata();
+        kubernetesClient.resource(flinkDeployment).delete();
+        return true;
+    }
+
+    private void initJob() {
+
+        String jarMainClass = config.getAppConfig().getUserJarMainAppClass();
+        String userJarPath = config.getAppConfig().getUserJarPath();
+        String[] userJarParas = config.getAppConfig().getUserJarParas();
+        String parallelism = flinkConfig.get("parallelism.default");
+
+        logger.info(
+                "\nThe app config is : \njarMainClass:{}\n userJarPath:{}\n userJarParas:{}\n ",
+                jarMainClass,
+                userJarPath,
+                userJarParas);
+        process.info(
+                String.format(
+                        "\nThe app config is : \njarMainClass:%s\n userJarPath:%s\n userJarParas:%s\n ",
+                        jarMainClass, userJarPath, Arrays.toString(userJarParas)));
+
+        if (Asserts.isNullString(jarMainClass) || Asserts.isNullString(userJarPath)) {
+            throw new IllegalArgumentException("jar MainClass or userJarPath must be config!!!");
+        }
+
+        JobSpec.JobSpecBuilder jobSpecBuilder =
+                JobSpec.builder()
+                        .entryClass(jarMainClass)
+                        .jarURI(userJarPath)
+                        .args(userJarParas)
+                        .parallelism(Integer.parseInt(parallelism));
+
+        if (Asserts.isNotNull(config.getFlinkConfig().getSavePoint())) {
+            String savePointPath = config.getFlinkConfig().getSavePoint();
+            jobSpecBuilder.initialSavepointPath(savePointPath);
+            jobSpecBuilder.upgradeMode(UpgradeMode.SAVEPOINT);
+
+            logger.info("find save point config, the path is : {}", savePointPath);
+            process.info(String.format("find save point config, the path is : %s", savePointPath));
+        } else {
+            jobSpecBuilder.upgradeMode(UpgradeMode.STATELESS);
+            logger.info("no save point config");
+            process.info("no save point config");
+        }
+
+        flinkDeploymentSpec.setJob(jobSpecBuilder.build());
+    }
+
+    private void initResource(KubernetesClient kubernetesClient) {
+        Pod defaultPod;
+        AbstractPodSpec jobManagerSpec = new AbstractPodSpec();
+        AbstractPodSpec taskManagerSpec = new AbstractPodSpec();
+        String jbcpu = submitConfiguration.getOrDefault("kubernetes.jobmanager.cpu", "1");
+        String jbmem = flinkConfig.getOrDefault("jobmanager.memory.process.size", "1G");
+        logger.info("jobmanager resource is : cpu-->{}, mem-->{}", jbcpu, jbmem);
+        process.info(String.format("jobmanager resource is : cpu-->%s, mem-->%s", jbcpu, jbmem));
+        jobManagerSpec.setResource(new Resource(Double.parseDouble(jbcpu), jbmem));
+
+        String tmcpu = submitConfiguration.getOrDefault("kubernetes.taskmanager.cpu", "1");
+        String tmmem = flinkConfig.getOrDefault("taskmanager.memory.process.size", "1G");
+        logger.info("taskmanager resource is : cpu-->{}, mem-->{}", tmcpu, tmmem);
+        process.info(String.format("taskmanager resource is : cpu-->%s, mem-->%s", tmcpu, tmmem));
+        taskManagerSpec.setResource(new Resource(Double.parseDouble(tmcpu), tmmem));
+
+        if (submitConfiguration.containsKey("kubernetes.pod-template")) {
+            InputStream inputStream =
+                    new ByteArrayInputStream(
+                            submitConfiguration
+                                    .get("kubernetes.pod-template")
+                                    .getBytes(StandardCharsets.UTF_8));
+            defaultPod = kubernetesClient.pods().load(inputStream).get();
+            flinkDeploymentSpec.setPodTemplate(defaultPod);
+        }
+        if (submitConfiguration.containsKey("kubernetes.pod-template.jobmanager")) {
+            InputStream inputStream =
+                    new ByteArrayInputStream(
+                            submitConfiguration
+                                    .get("kubernetes.pod-template.jobmanager")
+                                    .getBytes(StandardCharsets.UTF_8));
+            Pod pod = kubernetesClient.pods().load(inputStream).get();
+            jobManagerSpec.setPodTemplate(pod);
+        }
+        if (submitConfiguration.containsKey("kubernetes.pod-template.taskmanager")) {
+            InputStream inputStream =
+                    new ByteArrayInputStream(
+                            submitConfiguration
+                                    .get("kubernetes.pod-template.taskmanager")
+                                    .getBytes(StandardCharsets.UTF_8));
+            Pod pod = kubernetesClient.pods().load(inputStream).get();
+            taskManagerSpec.setPodTemplate(pod);
+        }
+        flinkDeploymentSpec.setJobManager(jobManagerSpec);
+        flinkDeploymentSpec.setTaskManager(taskManagerSpec);
+    }
+
+    private void initSpec() {
+        String flinkVersion = submitConfiguration.get("flinkVersion");
+        String image = submitConfiguration.get("kubernetes.container.image");
+        String serviceAccount = submitConfiguration.get("kubernetes.service.account");
+
+        logger.info("\nflinkVersion is : {} \n image is : {}", flinkVersion, image);
+        process.info(String.format("\nflinkVersion is : %s \n image is : %s", flinkVersion, image));
+
+        if (Asserts.isNotNull(flinkVersion)) {
+            flinkDeploymentSpec.setFlinkVersion(flinkVersion);
+        } else {
+            throw new IllegalArgumentException(
+                    "Flink version are not Set！！use Operator must be set!");
+        }
+
+        flinkDeploymentSpec.setImage(image);
+
+        flinkDeploymentSpec.setFlinkConfiguration(flinkConfig);
+        flinkDeployment.setSpec(flinkDeploymentSpec);
+
+        if (Asserts.isNotNull(serviceAccount)) {
+            flinkDeploymentSpec.setServiceAccount(serviceAccount);
+            logger.info("serviceAccount is : {}", serviceAccount);
+        } else {
+            logger.info("serviceAccount not config, use default");
+            flinkDeploymentSpec.setServiceAccount("default");
+        }
+    }
+
+    private void initBase() {
+        flinkDeployment.setApiVersion("flink.apache.org/v1beta1");
+        flinkDeployment.setKind("FlinkDeployment");
+
+        logger.info("ApiVersion is : {}", "flink.apache.org/v1beta1");
+        logger.info("Kind is : {}", "FlinkDeployment");
+    }
+
+    private void initMetadata() {
+        String jobName = config.getFlinkConfig().getJobName();
+        String nameSpace = submitConfiguration.get("kubernetes.namespace");
+
+        logger.info("\njobName is ：{} \n namespce is : {}", jobName, nameSpace);
+        process.info(String.format("\njobName is ：%s \n namespce is : %s", jobName, nameSpace));
+
+        // set Meta info , include pod name, namespace conf
+        ObjectMeta objectMeta = new ObjectMeta();
+        objectMeta.setName(jobName);
+        objectMeta.setNamespace(nameSpace);
+        flinkDeployment.setMetadata(objectMeta);
+    }
+
+    @Override
+    public SavePointResult savepointCluster(String savePoint) {
+        return null;
+    }
+
+    @Override
+    public SavePointResult savepointJob(String savePoint) {
+        return null;
+    }
+}

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubetnetsApplicationOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubetnetsApplicationOperatorGateway.java
@@ -79,11 +79,14 @@ public class KubetnetsApplicationOperatorGateway extends KubernetsOperatorGatewa
                             .resource(flinkDeployment)
                             .waitUntilCondition(
                                     flinkDeployment1 -> {
+                                        if (Asserts.isNull(flinkDeployment1.getStatus())) {
+                                            return false;
+                                        }
                                         String status =
-                                                flinkDeployment1
-                                                        .getStatus()
-                                                        .getJobManagerDeploymentStatus()
-                                                        .toString();
+                                                String.valueOf(
+                                                        flinkDeployment1
+                                                                .getStatus()
+                                                                .getJobManagerDeploymentStatus());
                                         logger.info("deploy kubernetes , status is : {}", status);
                                         process.info(
                                                 String.format(

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubetnetsApplicationOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubetnetsApplicationOperatorGateway.java
@@ -28,6 +28,7 @@ import org.dinky.process.model.ProcessEntity;
 import org.dinky.utils.LogUtil;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -64,11 +65,11 @@ public class KubetnetsApplicationOperatorGateway extends KubernetsOperatorGatewa
             KubernetesClient kubernetesClient = getKubernetesClient();
             FlinkDeployment flinkDeployment = getFlinkDeployment();
 
-            //            process.info("start delete old cluster ");
-            //            kubernetesClient.resource(flinkDeployment).delete();
-            //            kubernetesClient
-            //                    .resource(flinkDeployment)
-            //                    .waitUntilCondition(Objects::isNull, 1, TimeUnit.MINUTES);
+            process.info("start delete old cluster ");
+            kubernetesClient.resource(flinkDeployment).delete();
+            kubernetesClient
+                    .resource(flinkDeployment)
+                    .waitUntilCondition(Objects::isNull, 1, TimeUnit.MINUTES);
 
             process.info("start create cluster ");
 

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubetnetsApplicationOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubetnetsApplicationOperatorGateway.java
@@ -1,0 +1,160 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.gateway.kubernetes.operator;
+
+import org.dinky.assertion.Asserts;
+import org.dinky.gateway.GatewayType;
+import org.dinky.gateway.kubernetes.operator.api.FlinkDeployment;
+import org.dinky.gateway.result.GatewayResult;
+import org.dinky.gateway.result.KubernetesResult;
+import org.dinky.process.model.ProcessEntity;
+import org.dinky.utils.LogUtil;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.api.model.ListOptions;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+
+public class KubetnetsApplicationOperatorGateway extends KubernetsOperatorGateway {
+
+    private static final Logger logger =
+            LoggerFactory.getLogger(KubetnetsApplicationOperatorGateway.class);
+
+    @Override
+    public GatewayType getType() {
+        return GatewayType.KUBERNETES_APPLICATION_OPERATOR;
+    }
+
+    @Override
+    public GatewayResult submitJar() {
+        ProcessEntity process = getProcess();
+        process.info(String.format("start submit flink jar use %s", getType()));
+        logger.info("start submit flink jar use {}", getType());
+
+        KubernetesResult result = KubernetesResult.build(getType());
+
+        try {
+            init();
+
+            KubernetesClient kubernetesClient = getKubernetesClient();
+            FlinkDeployment flinkDeployment = getFlinkDeployment();
+
+            //            process.info("start delete old cluster ");
+            //            kubernetesClient.resource(flinkDeployment).delete();
+            //            kubernetesClient
+            //                    .resource(flinkDeployment)
+            //                    .waitUntilCondition(Objects::isNull, 1, TimeUnit.MINUTES);
+
+            process.info("start create cluster ");
+
+            kubernetesClient.resource(flinkDeployment).createOrReplace();
+
+            FlinkDeployment flinkDeploymentResult =
+                    kubernetesClient
+                            .resource(flinkDeployment)
+                            .waitUntilCondition(
+                                    flinkDeployment1 -> {
+                                        String status =
+                                                flinkDeployment1
+                                                        .getStatus()
+                                                        .getJobManagerDeploymentStatus()
+                                                        .toString();
+                                        logger.info("deploy kubernetes , status is : {}", status);
+                                        process.info(
+                                                String.format(
+                                                        "deploy kubernetes , status is : %s",
+                                                        status));
+
+                                        String error = flinkDeployment1.getStatus().getError();
+                                        if (Asserts.isNotNullString(error)) {
+                                            logger.info("deploy kubernetes error :{}", error);
+                                            process.info(
+                                                    String.format(
+                                                            "deploy kubernetes error :%s", error));
+                                            throw new RuntimeException(error);
+                                        }
+                                        if (status.equals("READY")) {
+                                            logger.info("deploy kubernetes success ");
+                                            process.info("deploy kubernetes success ");
+                                            String jobId =
+                                                    flinkDeployment1
+                                                            .getStatus()
+                                                            .getJobStatus()
+                                                            .getJobId();
+                                            result.setJids(Collections.singletonList(jobId));
+                                            return true;
+                                        }
+                                        return false;
+                                    },
+                                    2,
+                                    TimeUnit.MINUTES);
+
+            // sleep a time ,because some time the service will not be found
+            try {
+                Thread.sleep(3000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+            // get jobmanager addr by service
+            ListOptions options = new ListOptions();
+            String serviceName = config.getFlinkConfig().getJobName() + "-rest";
+            options.setFieldSelector("metadata.name=" + serviceName);
+            ServiceList list = kubernetesClient.services().list(options);
+            StringBuilder ipPort = new StringBuilder();
+            for (Service item : list.getItems()) {
+                ipPort.append(item.getSpec().getClusterIP());
+                for (ServicePort servicePort : item.getSpec().getPorts()) {
+                    if (servicePort.getName().equals("rest")) {
+                        ipPort.append(":").append(servicePort.getPort());
+                    }
+                }
+            }
+
+            result.setWebURL("http://" + ipPort);
+            result.setId(result.getJids().get(0) + System.currentTimeMillis());
+            result.success();
+        } catch (KubernetesClientException e) {
+            // some error while connecting to kube cluster
+            result.fail(LogUtil.getError(e));
+            process.error(LogUtil.getError(e));
+            e.printStackTrace();
+        }
+        logger.info(
+                "submit {} job finish, web url is {}, jobid is {}",
+                getType(),
+                result.getWebURL(),
+                result.getJids());
+        process.info(
+                String.format(
+                        "submit %s job finish, web url is %s, jobid is %s",
+                        getType(), result.getWebURL(), result.getJids()));
+
+        return result;
+    }
+}

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/AbstractPodSpec.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/AbstractPodSpec.java
@@ -17,34 +17,29 @@
  *
  */
 
-package org.dinky.model;
+package org.dinky.gateway.kubernetes.operator.api;
 
-import java.util.Map;
+import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import lombok.Getter;
-import lombok.Setter;
+import io.fabric8.kubernetes.api.model.Pod;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
-/**
- * @author ZackYoung
- * @since
- */
-@Getter
-@Setter
-public class FlinkClusterConfiguration {
-    private Type type;
-    private String hadoopConfigPath;
-    private String flinkConfigPath;
-    private String flinkLibPath;
-    private String userJarPath;
-    private String flinkVersion;
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AbstractPodSpec {
+    private Resource resource;
+    private int replicas = 1;
+    private Pod podTemplate;
 
-    Map<String, String> flinkConfig;
-    Map<String, String> kubernetesConfig;
+    public AbstractPodSpec() {}
 
-    public enum Type {
-        //
-        Yarn,
-        Kubernetes,
-        KubernetesOperator;
+    @Data
+    @AllArgsConstructor
+    public static class Resource {
+        private Double cpu;
+        private String memory;
+
+        public Resource() {}
     }
 }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/AbstractPodSpec.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/AbstractPodSpec.java
@@ -19,7 +19,7 @@
 
 package org.dinky.gateway.kubernetes.operator.api;
 
-import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import lombok.AllArgsConstructor;

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/FlinkDeployment.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/FlinkDeployment.java
@@ -20,9 +20,9 @@
 package org.dinky.gateway.kubernetes.operator.api;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonInclude;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.fabric8.kubernetes.api.model.Namespaced;

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/FlinkDeployment.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/FlinkDeployment.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.gateway.kubernetes.operator.api;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonInclude;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.ShortNames;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Experimental
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize()
+@Group("flink.apache.org")
+@Version("v1beta1")
+@ShortNames({"flinkdep"})
+public class FlinkDeployment extends CustomResource<FlinkDeploymentSpec, FlinkDeploymentStatus>
+        implements Namespaced {}

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/FlinkDeploymentSpec.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/FlinkDeploymentSpec.java
@@ -20,9 +20,10 @@
 package org.dinky.gateway.kubernetes.operator.api;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import lombok.AllArgsConstructor;

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/FlinkDeploymentSpec.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/FlinkDeploymentSpec.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.gateway.kubernetes.operator.api;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Experimental
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString(callSuper = true)
+@SuperBuilder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FlinkDeploymentSpec {
+    private JobSpec job;
+    private Long restartNonce;
+    private Map<String, String> flinkConfiguration;
+    private String image;
+    private String imagePullPolicy;
+    private String serviceAccount;
+    private String flinkVersion;
+    private Pod podTemplate;
+    private AbstractPodSpec jobManager;
+    private AbstractPodSpec taskManager;
+    private Map<String, String> logConfiguration;
+}

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/FlinkDeploymentStatus.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/FlinkDeploymentStatus.java
@@ -20,10 +20,11 @@
 package org.dinky.gateway.kubernetes.operator.api;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import io.fabric8.kubernetes.model.annotation.PrinterColumn;
 import lombok.AllArgsConstructor;

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/FlinkDeploymentStatus.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/FlinkDeploymentStatus.java
@@ -1,0 +1,60 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.gateway.kubernetes.operator.api;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.fabric8.kubernetes.model.annotation.PrinterColumn;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Experimental
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString(callSuper = true)
+@SuperBuilder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FlinkDeploymentStatus {
+    private JobStatus jobStatus = new JobStatus();
+    private String error;
+    private Map<String, String> clusterInfo = new HashMap<>();
+    private String jobManagerDeploymentStatus = "MISSING";
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class JobStatus {
+        private String jobName;
+        private String jobId;
+
+        @PrinterColumn(name = "Job Status")
+        private String state;
+
+        private String startTime;
+        private String updateTime;
+    }
+}

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/JobSpec.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/JobSpec.java
@@ -20,7 +20,8 @@
 package org.dinky.gateway.kubernetes.operator.api;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/JobSpec.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/JobSpec.java
@@ -17,34 +17,31 @@
  *
  */
 
-package org.dinky.model;
+package org.dinky.gateway.kubernetes.operator.api;
 
-import java.util.Map;
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
-/**
- * @author ZackYoung
- * @since
- */
-@Getter
-@Setter
-public class FlinkClusterConfiguration {
-    private Type type;
-    private String hadoopConfigPath;
-    private String flinkConfigPath;
-    private String flinkLibPath;
-    private String userJarPath;
-    private String flinkVersion;
-
-    Map<String, String> flinkConfig;
-    Map<String, String> kubernetesConfig;
-
-    public enum Type {
-        //
-        Yarn,
-        Kubernetes,
-        KubernetesOperator;
-    }
+@Experimental
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JobSpec {
+    private String jarURI;
+    private int parallelism;
+    private String entryClass;
+    private String[] args = new String[0];
+    private Long savepointTriggerNonce;
+    private String initialSavepointPath;
+    private UpgradeMode upgradeMode = UpgradeMode.STATELESS;
+    private Boolean allowNonRestoredState;
 }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/UpgradeMode.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/UpgradeMode.java
@@ -20,8 +20,9 @@
 package org.dinky.gateway.kubernetes.operator.api;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Experimental
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/UpgradeMode.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/UpgradeMode.java
@@ -17,34 +17,19 @@
  *
  */
 
-package org.dinky.model;
+package org.dinky.gateway.kubernetes.operator.api;
 
-import java.util.Map;
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.kubernetes.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.Getter;
-import lombok.Setter;
-
-/**
- * @author ZackYoung
- * @since
- */
-@Getter
-@Setter
-public class FlinkClusterConfiguration {
-    private Type type;
-    private String hadoopConfigPath;
-    private String flinkConfigPath;
-    private String flinkLibPath;
-    private String userJarPath;
-    private String flinkVersion;
-
-    Map<String, String> flinkConfig;
-    Map<String, String> kubernetesConfig;
-
-    public enum Type {
-        //
-        Yarn,
-        Kubernetes,
-        KubernetesOperator;
-    }
+@Experimental
+@JsonIgnoreProperties(ignoreUnknown = true)
+public enum UpgradeMode {
+    @JsonProperty("savepoint")
+    SAVEPOINT,
+    @JsonProperty("last-state")
+    LAST_STATE,
+    @JsonProperty("stateless")
+    STATELESS
 }

--- a/dinky-gateway/src/main/resources/META-INF/services/org.dinky.gateway.Gateway
+++ b/dinky-gateway/src/main/resources/META-INF/services/org.dinky.gateway.Gateway
@@ -3,3 +3,4 @@ org.dinky.gateway.yarn.YarnPerJobGateway
 org.dinky.gateway.yarn.YarnSessionGateway
 org.dinky.gateway.kubernetes.KubernetesApplicationGateway
 org.dinky.gateway.kubernetes.KubernetesSessionGateway
+org.dinky.gateway.kubernetes.operator.KubetnetsApplicationOperatorGateway

--- a/dlink-web/src/components/Studio/StudioKubernetes/index.tsx
+++ b/dlink-web/src/components/Studio/StudioKubernetes/index.tsx
@@ -129,8 +129,11 @@ const StudioKubernetes = (props: any) => {
     const values = getConfig(all)
     let appConfig = {}
     APP_CONFIG_LIST.forEach((value, index) => {
-      appConfig[APP_CONFIG_LIST[index].name] = all[APP_CONFIG_LIST[index].name]
+      if(all[APP_CONFIG_LIST[index].name]){
+        appConfig[APP_CONFIG_LIST[index].name] = all[APP_CONFIG_LIST[index].name]
+      }
     })
+
     setFormVals(all)
     props.saveSql(JSON.stringify({...values,"appConfig":appConfig}))
   }

--- a/dlink-web/src/components/Studio/StudioRightTool/StudioKubernetesConfig/index.tsx
+++ b/dlink-web/src/components/Studio/StudioRightTool/StudioKubernetesConfig/index.tsx
@@ -48,12 +48,14 @@ const StudioKubernetesConfig = (props: any) => {
 
   const getClusterConfigurationOptions = () => {
     const itemList = [];
+
     for (const item of clusterConfiguration) {
+
       const tag = (<><Tag color={item.enabled ? "processing" : "error"}>{item.type}</Tag>{item.name}</>);
       //opeartor mode can not have normal application config
-      if (current.task.type == 'kubernetes-application-operator' && item.type == 'FlinkKubernetesOperator'){
+      if (current.task.type == 'kubernetes-application-operator' && item.type == 'KubernetesOperator'){
         itemList.push(<Option key={item.id} value={item.id} label={tag}>{tag}</Option>)
-      }else if (current.task.type != 'kubernetes-application-operator'  && item.type != 'FlinkKubernetesOperator'){
+      }else if (current.task.type != 'kubernetes-application-operator'  && item.type != 'KubernetesOperator'){
         //if not operator mode , add it normal
         itemList.push(<Option key={item.id} value={item.id} label={tag}>{tag}</Option>)
       }
@@ -122,6 +124,7 @@ const StudioKubernetesConfig = (props: any) => {
           >
             <Select defaultValue={RUN_MODE.KUBERNETES_APPLICATION} value={RUN_MODE.KUBERNETES_APPLICATION}>
               <Option value={RUN_MODE.KUBERNETES_APPLICATION}>Kubernetes Application Native</Option>
+              <Option value={RUN_MODE.KUBERNETES_APPLICATION_OPERATOR}>Kubernetes Application Operator</Option>
             </Select>
           </Form.Item>
 

--- a/dlink-web/src/components/Studio/StudioRightTool/StudioSetting/index.tsx
+++ b/dlink-web/src/components/Studio/StudioRightTool/StudioSetting/index.tsx
@@ -163,6 +163,7 @@ const StudioSetting = (props: any) => {
               <Option value={RUN_MODE.YARN_APPLICATION}>Yarn Application</Option>
               <Option value={RUN_MODE.KUBERNETES_SESSION}>Kubernetes Session</Option>
               <Option value={RUN_MODE.KUBERNETES_APPLICATION}>Kubernetes Application</Option>
+              <Option value={RUN_MODE.KUBERNETES_APPLICATION_OPERATOR}>Kubernetes Operator Application</Option>
             </Select>
           </Form.Item>
           {(current.task.type === RUN_MODE.YARN_SESSION || current.task.type === RUN_MODE.KUBERNETES_SESSION || current.task.type === RUN_MODE.STANDALONE) ? (
@@ -192,7 +193,8 @@ const StudioSetting = (props: any) => {
                 </Form.Item>
               </Col>
             </Row>) : undefined}
-          {(current.task.type === RUN_MODE.YARN_PER_JOB || current.task.type === RUN_MODE.YARN_APPLICATION || current.task.type === RUN_MODE.KUBERNETES_APPLICATION) ? (
+          {(current.task.type === RUN_MODE.YARN_PER_JOB || current.task.type === RUN_MODE.YARN_APPLICATION
+          || current.task.type === RUN_MODE.KUBERNETES_APPLICATION|| current.task.type === RUN_MODE.KUBERNETES_APPLICATION_OPERATOR) ? (
             <Row>
               <Col span={24}>
                 <Form.Item label={l('pages.datastudio.label.jobConfig.clusterConfig')}

--- a/dlink-web/src/components/Studio/conf.ts
+++ b/dlink-web/src/components/Studio/conf.ts
@@ -26,6 +26,7 @@ export const RUN_MODE = {
   YARN_APPLICATION: 'yarn-application',
   KUBERNETES_SESSION: 'kubernetes-session',
   KUBERNETES_APPLICATION: 'kubernetes-application',
+  KUBERNETES_APPLICATION_OPERATOR: 'kubernetes-application-operator',
 };
 
 export const DIALECT = {

--- a/dlink-web/src/pages/RegistrationCenter/ClusterManage/ClusterConfiguration/components/ClusterConfigurationForm.tsx
+++ b/dlink-web/src/pages/RegistrationCenter/ClusterManage/ClusterConfiguration/components/ClusterConfigurationForm.tsx
@@ -102,6 +102,7 @@ const ClusterConfigurationForm: React.FC<ClusterConfigurationFormProps> = (props
 
   const submitForm = async () => {
     const fieldsValue = await form.validateFields();
+
     const formValues = {
       id: formVals.id,
       name: fieldsValue.name,
@@ -110,6 +111,7 @@ const ClusterConfigurationForm: React.FC<ClusterConfigurationFormProps> = (props
       enabled: fieldsValue.enabled,
       configJson: JSON.stringify(getConfig(fieldsValue)),
     };
+
     setFormVals(formValues);
     handleSubmit(formValues);
   };
@@ -201,6 +203,27 @@ const ClusterConfigurationForm: React.FC<ClusterConfigurationFormProps> = (props
           )}
         </Form.List>
       </Form.Item>
+    )
+  }
+
+  const renderFlinkKubernetesOperatorPage = (formValsPara: Partial<ClusterConfigurationTableListItem>) => {
+    return (
+      <>
+        <Divider>{l('pages.rc.clusterConfig.k8sConfig')}</Divider>
+        <Form.Item
+          name="flinkVersion"
+          label={l('pages.rc.clusterConfig.kubernets.version')}
+        >
+          <Select>
+            <Option value="v1_13">v1_13 ({l('pages.rc.clusterConfig.kubernets.unsupportBatch')})</Option>
+            <Option value="v1_14">v1_14 ({l('pages.rc.clusterConfig.kubernets.unsupportBatch')})</Option>
+            <Option value="v1_15">v1_15</Option>
+            <Option value="v1_16">v1_16</Option>
+          </Select>
+        </Form.Item>
+        {buildConfig(KUBERNETES_CONFIG_LIST, formValsPara)}
+
+      </>
     )
   }
 
@@ -302,13 +325,15 @@ const ClusterConfigurationForm: React.FC<ClusterConfigurationFormProps> = (props
           <Select defaultValue="Yarn" value="Yarn">
             <Option value="Yarn">Flink On Yarn</Option>
             <Option value="Kubernetes">Flink Kubernetes Native</Option>
-            {/*<Option value="FlinkKubernetesOperator">Flink Kubernetes Operator</Option>*/}
+            <Option value="KubernetesOperator">Flink Kubernetes Operator</Option>
           </Select>
         </Form.Item>
 
         {formValsPara.type == 'Yarn' ? renderYarnPage(formValsPara) : undefined}
 
         {formValsPara.type == 'Kubernetes' ? renderFlinkKubernetesNativePage(formValsPara) : undefined}
+
+        {formValsPara.type == 'KubernetesOperator' ? renderFlinkKubernetesOperatorPage(formValsPara) : undefined}
 
 
         <Divider orientation="left" plain>{l('pages.rc.clusterConfig.defineConfig.highPriority')}</Divider>

--- a/dlink-web/src/pages/RegistrationCenter/ClusterManage/ClusterConfiguration/conf.ts
+++ b/dlink-web/src/pages/RegistrationCenter/ClusterManage/ClusterConfiguration/conf.ts
@@ -107,6 +107,30 @@ export const KUBERNETES_CONFIG_LIST: Config[] = [
     lable: 'kubernetes.config.file',
     showType: 'input',
     placeholder: l('pages.rc.clusterConfig.help.kubernetes.configfile'),
+  },{
+    name: 'kubernetes.service.account',
+    lable: 'kubernetes.service.account',
+    placeholder: l('pages.rc.clusterConfig.help.kubernets.account'),
+    showType: 'input',
+    showOnSubmitType: 'KubernetesOperator'
+  },{
+    name: 'kubernetes.pod-template',
+    lable: 'kubernetes.pod-template',
+    placeholder: l('pages.rc.clusterConfig.help.kubernets.defaultTemplate'),
+    showType: 'textarea',
+    showOnSubmitType: 'KubernetesOperator'
+  },{
+    name: 'kubernetes.pod-template.jobmanager',
+    lable: 'kubernetes.pod-template.jobmanager',
+    placeholder: l('pages.rc.clusterConfig.help.kubernets.jobManagerTemplate'),
+    showType: 'textarea',
+    showOnSubmitType: 'KubernetesOperator'
+  },{
+    name: 'kubernetes.pod-template.taskmanager',
+    lable: 'kubernetes.pod-template.taskmanager',
+    placeholder: l('pages.rc.clusterConfig.help.kubernets.taskManagerTemplate'),
+    showType: 'textarea',
+    showOnSubmitType: 'KubernetesOperator'
   }
 ];
 export const FLINK_CONFIG_LIST: Config[] = [

--- a/dlink-web/src/pages/RegistrationCenter/ClusterManage/ClusterConfiguration/function.ts
+++ b/dlink-web/src/pages/RegistrationCenter/ClusterManage/ClusterConfiguration/function.ts
@@ -53,6 +53,20 @@ export function getConfig(values: any) {
       userJarPath: values.userJarPath,
       flinkConfig,
     };
+  }else if(values.type=='KubernetesOperator') {
+    let kubernetesConfig = addValueToMap(values, KUBERNETES_CONFIG_NAME_LIST());
+    addListToMap(values.kubernetesConfigList, kubernetesConfig);
+    let dockerConfig = addValueToMap(values, DOCKER_CONFIG_NAME_LIST());
+    let flinkVersion = values.flinkVersion
+    return {
+      flinkLibPath: values.flinkLibPath,
+      flinkConfigPath: values.flinkConfigPath,
+      kubernetesConfig,
+      dockerConfig,
+      userJarPath: values.userJarPath,
+      flinkConfig,
+      flinkVersion
+    };
   } else {
     //all code paths must return a value.
     return {}
@@ -79,12 +93,15 @@ function addValueToMap(values: {}, keys: string []) {
     return config;
   }
   for (let i in keys) {
-    config[keys[i]] = values[keys[i]];
+    if(values[keys[i]]){
+      config[keys[i]] = values[keys[i]];
+    }
   }
   return config;
 }
 
 export function getConfigFormValues(values: any) {
+
   if (!values.id) {
     return {type: values.type};
   }
@@ -97,10 +114,12 @@ export function getConfigFormValues(values: any) {
     'enabled',
   ]);
   let config = JSON.parse(values.configJson);
+
   let configValues = addValueToMap(config, [
     'hadoopConfigPath',
     'flinkLibPath',
     'flinkConfigPath',
+    'flinkVersion',
   ]);
   let hadoopConfig = addValueToMap(config.hadoopConfig, HADOOP_CONFIG_NAME_LIST());
   let userJarPath = config.userJarPath;


### PR DESCRIPTION
1. 增加对k8s operator提交方式支持
2. 取消使用flink-k8s-operator-api引入，仅重写部分关键代码负责提交功能即可，可以支持java8与java11
