### PR TITLE
fix sql annotations replace bug

### DIFF
--- a/dinky-admin/src/test/java/org/dinky/utils/SqlUtilTest.java
+++ b/dinky-admin/src/test/java/org/dinky/utils/SqlUtilTest.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.utils;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/** DirUtilTest */
+@Ignore
+public class SqlUtilTest {
+
+    @Test
+    public void testRemoveNote() {
+        String testSql =
+                "/**\n"
+                        + "test1\n"
+                        + "*/\n"
+                        + "//test2\n"
+                        + "-- test3\n"
+                        + "--test4\n"
+                        + "select 1 --test5\n"
+                        + " from test # test9\n"
+                        + " where '1'  <> '-- ::.' //test6\n"
+                        + " and 1=1 --test7\n"
+                        + " and 'zz' <> null; /**test8*/";
+
+        String removedNoteSql = SqlUtil.removeNote(testSql);
+        Assertions.assertThat(removedNoteSql).isNotNull();
+        Assertions.assertThat(removedNoteSql).isNotEqualTo(testSql);
+    }
+}

--- a/dinky-common/src/main/java/org/dinky/utils/SqlUtil.java
+++ b/dinky-common/src/main/java/org/dinky/utils/SqlUtil.java
@@ -23,6 +23,7 @@ import org.dinky.assertion.Asserts;
 import org.dinky.model.SystemConfiguration;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * SqlUtil
@@ -53,12 +54,15 @@ public class SqlUtil {
     }
 
     public static String removeNote(String sql) {
+
         if (Asserts.isNotNullString(sql)) {
-            sql =
-                    sql.replaceAll("\u00A0", " ")
-                            .replaceAll("[\r\n]+", "\n")
-                            .replaceAll("--([^'\n]{0,}('[^'\n]{0,}'){0,1}[^'\n]{0,}){0,}", "")
-                            .trim();
+            // Remove the special-space characters
+            sql = sql.replaceAll("\u00A0", " ")
+                    .replaceAll("[\r\n]+", "\n");
+            //Remove annotations Support '--aa' , '/**aaa*/' , '//aa' , '#aaa'
+            Pattern p = Pattern.compile("(?ms)('(?:''|[^'])*')|--.*?$|//.*?$|/\\*.*?\\*/|#.*?$|");
+            String presult = p.matcher(sql).replaceAll("$1");
+            return presult.trim();
         }
         return sql;
     }

--- a/dinky-common/src/main/java/org/dinky/utils/SqlUtil.java
+++ b/dinky-common/src/main/java/org/dinky/utils/SqlUtil.java
@@ -57,9 +57,8 @@ public class SqlUtil {
 
         if (Asserts.isNotNullString(sql)) {
             // Remove the special-space characters
-            sql = sql.replaceAll("\u00A0", " ")
-                    .replaceAll("[\r\n]+", "\n");
-            //Remove annotations Support '--aa' , '/**aaa*/' , '//aa' , '#aaa'
+            sql = sql.replaceAll("\u00A0", " ").replaceAll("[\r\n]+", "\n");
+            // Remove annotations Support '--aa' , '/**aaa*/' , '//aa' , '#aaa'
             Pattern p = Pattern.compile("(?ms)('(?:''|[^'])*')|--.*?$|//.*?$|/\\*.*?\\*/|#.*?$|");
             String presult = p.matcher(sql).replaceAll("$1");
             return presult.trim();


### PR DESCRIPTION
## Purpose of the pull request
fix #1883
The sql annotation replacement method is optimized to support more annotation methods

Repair the incorrect annotation match, the annotation content within the quotes is not replaced

# How to test

use sql
```sql
/**
test1
*/
//test2
-- test3
--test4
select 1 --test5
 from test # test9
 where '1'  <> '-- ::.' //test6
 and 1=1 --test7
 and 'zz' <> null; /**test8*/
```

the true formate result is 
```sql
select 1 
 from test 
 where '1'  <> '-- ::.' 
 and 1=1 
 and 'zz' <> null; 
```