### PR TITLE
FIXBUG:修复mysql自动生成DDL语句时，没有数据类型的问题

### DIFF
--- a/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/driver/MySqlDriver.java
+++ b/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/driver/MySqlDriver.java
@@ -106,6 +106,7 @@ public class MySqlDriver extends AbstractJdbcDriver {
                     && column.getType().toLowerCase().contains("unsigned")) {
                 sb.append(column.getType().replaceAll("(?i)unsigned", "(" + column.getLength() + ") unsigned"));
             } else {
+                sb.append(column.getType());
                 // 处理浮点类型
                 if (column.getPrecision() > 0 && column.getScale() > 0) {
                     sb.append("(")


### PR DESCRIPTION
上一个版本在处理unsigned问题时，遗漏了不带unsigned字段的数据类型，造成数据类型如果不带unsigned，无法展示!

## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
