### PR TITLE
feat: add official `add jar` sql syntax, and rename custom `add jar` to `add customJar`

### DIFF
--- a/dinky-client/dinky-client-1.13/src/main/java/org/dinky/executor/CustomTableEnvironmentImpl.java
+++ b/dinky-client/dinky-client-1.13/src/main/java/org/dinky/executor/CustomTableEnvironmentImpl.java
@@ -19,8 +19,6 @@
 
 package org.dinky.executor;
 
-import cn.hutool.core.util.ReflectUtil;
-import java.lang.reflect.InvocationTargetException;
 import org.dinky.assertion.Asserts;
 import org.dinky.model.LineageRel;
 import org.dinky.result.SqlExplainResult;
@@ -72,6 +70,7 @@ import org.apache.flink.table.planner.plan.optimize.program.FlinkChainedProgram;
 import org.apache.flink.table.planner.utils.ExecutorUtils;
 import org.apache.flink.table.typeutils.FieldInfoUtils;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -82,6 +81,8 @@ import java.util.Optional;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import cn.hutool.core.util.ReflectUtil;
 
 /**
  * 定制TableEnvironmentImpl
@@ -335,12 +336,13 @@ public class CustomTableEnvironmentImpl extends AbstractCustomTableEnvironment {
 
     @Override
     public Configuration getRootConfiguration() {
-        Method method = ReflectUtil.getMethod(this.getStreamExecutionEnvironment().getClass(),
-            "getConfiguration");
+        Method method =
+                ReflectUtil.getMethod(
+                        this.getStreamExecutionEnvironment().getClass(), "getConfiguration");
         ReflectUtil.setAccessible(method);
         try {
             Object object = method.invoke(this.getStreamExecutionEnvironment());
-            return (Configuration)object;
+            return (Configuration) object;
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }

--- a/dinky-client/dinky-client-1.13/src/main/java/org/dinky/executor/CustomTableEnvironmentImpl.java
+++ b/dinky-client/dinky-client-1.13/src/main/java/org/dinky/executor/CustomTableEnvironmentImpl.java
@@ -19,6 +19,8 @@
 
 package org.dinky.executor;
 
+import cn.hutool.core.util.ReflectUtil;
+import java.lang.reflect.InvocationTargetException;
 import org.dinky.assertion.Asserts;
 import org.dinky.model.LineageRel;
 import org.dinky.result.SqlExplainResult;
@@ -329,6 +331,19 @@ public class CustomTableEnvironmentImpl extends AbstractCustomTableEnvironment {
             }
         }
         return false;
+    }
+
+    @Override
+    public Configuration getRootConfiguration() {
+        Method method = ReflectUtil.getMethod(this.getStreamExecutionEnvironment().getClass(),
+            "getConfiguration");
+        ReflectUtil.setAccessible(method);
+        try {
+            Object object = method.invoke(this.getStreamExecutionEnvironment());
+            return (Configuration)object;
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private void callSet(

--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
@@ -54,9 +54,4 @@ public abstract class AbstractCustomTableEnvironment
     public Planner getPlanner() {
         return ((StreamTableEnvironmentImpl) streamTableEnvironment).getPlanner();
     }
-
-    @Override
-    public Configuration getRootConfiguration() {
-        return (Configuration) this.getConfig().getRootConfiguration();
-    }
 }

--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
@@ -53,4 +53,9 @@ public abstract class AbstractCustomTableEnvironment
     public Planner getPlanner() {
         return ((StreamTableEnvironmentImpl) streamTableEnvironment).getPlanner();
     }
+
+    @Override
+    public Configuration getRootConfiguration(){
+        (Configuration) this.getConfig().getRootConfiguration();
+    }
 }

--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
@@ -19,13 +19,13 @@
 
 package org.dinky.executor;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.bridge.java.internal.StreamTableEnvironmentImpl;
 import org.apache.flink.table.delegation.Executor;
 import org.apache.flink.table.delegation.Planner;
-import org.apache.flink.configuration.Configuration;
 
 /** */
 public abstract class AbstractCustomTableEnvironment

--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.bridge.java.internal.StreamTableEnvironmentImpl;
 import org.apache.flink.table.delegation.Executor;
 import org.apache.flink.table.delegation.Planner;
+import org.apache.flink.configuration.Configuration;
 
 /** */
 public abstract class AbstractCustomTableEnvironment

--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
@@ -55,7 +55,7 @@ public abstract class AbstractCustomTableEnvironment
     }
 
     @Override
-    public Configuration getRootConfiguration(){
-        (Configuration) this.getConfig().getRootConfiguration();
+    public Configuration getRootConfiguration() {
+        return (Configuration) this.getConfig().getRootConfiguration();
     }
 }

--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
@@ -19,7 +19,6 @@
 
 package org.dinky.executor;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;

--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/CustomTableEnvironmentImpl.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/CustomTableEnvironmentImpl.java
@@ -19,8 +19,6 @@
 
 package org.dinky.executor;
 
-import cn.hutool.core.util.ReflectUtil;
-import java.lang.reflect.InvocationTargetException;
 import org.dinky.assertion.Asserts;
 import org.dinky.model.LineageRel;
 import org.dinky.result.SqlExplainResult;
@@ -71,6 +69,7 @@ import org.apache.flink.table.planner.delegation.DefaultExecutor;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkChainedProgram;
 import org.apache.flink.table.typeutils.FieldInfoUtils;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -81,6 +80,8 @@ import java.util.Optional;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import cn.hutool.core.util.ReflectUtil;
 
 /**
  * 定制TableEnvironmentImpl
@@ -189,8 +190,8 @@ public class CustomTableEnvironmentImpl extends AbstractCustomTableEnvironment {
     @Override
     public Configuration getRootConfiguration() {
         Method method =
-            ReflectUtil.getMethod(
-                this.getStreamExecutionEnvironment().getClass(), "getConfiguration");
+                ReflectUtil.getMethod(
+                        this.getStreamExecutionEnvironment().getClass(), "getConfiguration");
         ReflectUtil.setAccessible(method);
         try {
             Object object = method.invoke(this.getStreamExecutionEnvironment());

--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/CustomTableEnvironmentImpl.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/executor/CustomTableEnvironmentImpl.java
@@ -19,6 +19,8 @@
 
 package org.dinky.executor;
 
+import cn.hutool.core.util.ReflectUtil;
+import java.lang.reflect.InvocationTargetException;
 import org.dinky.assertion.Asserts;
 import org.dinky.model.LineageRel;
 import org.dinky.result.SqlExplainResult;
@@ -182,6 +184,20 @@ public class CustomTableEnvironmentImpl extends AbstractCustomTableEnvironment {
                 executor,
                 settings.isStreamingMode(),
                 classLoader);
+    }
+
+    @Override
+    public Configuration getRootConfiguration() {
+        Method method =
+            ReflectUtil.getMethod(
+                this.getStreamExecutionEnvironment().getClass(), "getConfiguration");
+        ReflectUtil.setAccessible(method);
+        try {
+            Object object = method.invoke(this.getStreamExecutionEnvironment());
+            return (Configuration) object;
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static Executor lookupExecutor(

--- a/dinky-client/dinky-client-1.15/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
+++ b/dinky-client/dinky-client-1.15/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
@@ -53,7 +53,7 @@ public abstract class AbstractCustomTableEnvironment
     }
 
     @Override
-    public Configuration getRootConfiguration(){
-        (Configuration) this.getConfig().getRootConfiguration();
+    public Configuration getRootConfiguration() {
+        return (Configuration) this.getConfig().getRootConfiguration();
     }
 }

--- a/dinky-client/dinky-client-1.15/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
+++ b/dinky-client/dinky-client-1.15/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
@@ -19,6 +19,7 @@
 
 package org.dinky.executor;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;

--- a/dinky-client/dinky-client-1.15/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
+++ b/dinky-client/dinky-client-1.15/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
@@ -51,4 +51,9 @@ public abstract class AbstractCustomTableEnvironment
     public Planner getPlanner() {
         return ((StreamTableEnvironmentImpl) streamTableEnvironment).getPlanner();
     }
+
+    @Override
+    public Configuration getRootConfiguration(){
+        (Configuration) this.getConfig().getRootConfiguration();
+    }
 }

--- a/dinky-client/dinky-client-1.16/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
+++ b/dinky-client/dinky-client-1.16/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
@@ -19,6 +19,7 @@
 
 package org.dinky.executor;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;

--- a/dinky-client/dinky-client-1.16/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
+++ b/dinky-client/dinky-client-1.16/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
@@ -73,8 +73,7 @@ public abstract class AbstractCustomTableEnvironment
     }
 
     @Override
-    public Configuration getRootConfiguration(){
-        (Configuration) this.getConfig().getRootConfiguration();
+    public Configuration getRootConfiguration() {
+        return (Configuration) this.getConfig().getRootConfiguration();
     }
-
 }

--- a/dinky-client/dinky-client-1.16/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
+++ b/dinky-client/dinky-client-1.16/src/main/java/org/dinky/executor/AbstractCustomTableEnvironment.java
@@ -71,4 +71,10 @@ public abstract class AbstractCustomTableEnvironment
         ReflectUtil.setFieldValue(
                 getPlanner(), "extendedOperationExecutor", extendedOperationExecutor);
     }
+
+    @Override
+    public Configuration getRootConfiguration(){
+        (Configuration) this.getConfig().getRootConfiguration();
+    }
+
 }

--- a/dinky-client/dinky-client-base/src/main/java/org/dinky/executor/CustomTableEnvironment.java
+++ b/dinky-client/dinky-client-base/src/main/java/org/dinky/executor/CustomTableEnvironment.java
@@ -63,6 +63,7 @@ public interface CustomTableEnvironment
     Planner getPlanner();
 
     Configuration getRootConfiguration();
+
     default List<LineageRel> getLineage(String statement) {
         return null;
     }

--- a/dinky-client/dinky-client-base/src/main/java/org/dinky/executor/CustomTableEnvironment.java
+++ b/dinky-client/dinky-client-base/src/main/java/org/dinky/executor/CustomTableEnvironment.java
@@ -22,6 +22,7 @@ package org.dinky.executor;
 import org.dinky.model.LineageRel;
 import org.dinky.result.SqlExplainResult;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -61,6 +62,7 @@ public interface CustomTableEnvironment
 
     Planner getPlanner();
 
+    Configuration getRootConfiguration();
     default List<LineageRel> getLineage(String statement) {
         return null;
     }

--- a/dinky-core/src/main/java/org/dinky/explainer/Explainer.java
+++ b/dinky-core/src/main/java/org/dinky/explainer/Explainer.java
@@ -113,9 +113,6 @@ public class Explainer {
                         .forEach(JarPathContextHolder::addOtherPlugins);
                 DinkyClassLoaderContextHolder.get()
                         .addURL(URLUtils.getURLs(JarPathContextHolder.getOtherPluginsFiles()));
-            } else if (operationType.equals(SqlType.ADD_JAR)) {
-                ddl.add(new StatementParam(statement, operationType));
-                statementList.add(statement);
             } else if (operationType.equals(SqlType.INSERT)
                     || operationType.equals(SqlType.SELECT)
                     || operationType.equals(SqlType.SHOW)

--- a/dinky-core/src/main/java/org/dinky/explainer/Explainer.java
+++ b/dinky-core/src/main/java/org/dinky/explainer/Explainer.java
@@ -102,7 +102,7 @@ public class Explainer {
         List<StatementParam> execute = new ArrayList<>();
         List<String> statementList = new ArrayList<>();
         List<UDF> udfList = new ArrayList<>();
-                for (String item : statements) {
+        for (String item : statements) {
             String statement = executor.pretreatStatement(item);
             if (statement.isEmpty()) {
                 continue;

--- a/dinky-core/src/main/java/org/dinky/explainer/Explainer.java
+++ b/dinky-core/src/main/java/org/dinky/explainer/Explainer.java
@@ -158,7 +158,7 @@ public class Explainer {
 
     private Configuration getCombinationConfig() {
         CustomTableEnvironment cte = executor.getCustomTableEnvironment();
-        Configuration rootConfig = (Configuration) cte.getConfig().getRootConfiguration();
+        Configuration rootConfig = cte.getRootConfiguration();
         Configuration config = cte.getConfig().getConfiguration();
         Configuration combinationConfig = new Configuration();
         combinationConfig.addAll(rootConfig);

--- a/dinky-core/src/main/java/org/dinky/explainer/Explainer.java
+++ b/dinky-core/src/main/java/org/dinky/explainer/Explainer.java
@@ -19,8 +19,6 @@
 
 package org.dinky.explainer;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.fs.FileSystem;
 import org.dinky.assertion.Asserts;
 import org.dinky.constant.FlinkSQLConstant;
 import org.dinky.context.DinkyClassLoaderContextHolder;
@@ -48,6 +46,8 @@ import org.dinky.utils.LogUtil;
 import org.dinky.utils.SqlUtil;
 import org.dinky.utils.URLUtils;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 
 import java.time.LocalDateTime;
@@ -118,7 +118,7 @@ public class Explainer {
                         .addURL(URLUtils.getURLs(JarPathContextHolder.getOtherPluginsFiles()));
             } else if (operationType.equals(SqlType.ADD_JAR)) {
                 Configuration combinationConfig = getCombinationConfig();
-                FileSystem.initialize(combinationConfig,null);
+                FileSystem.initialize(combinationConfig, null);
                 ddl.add(new StatementParam(statement, operationType));
                 statementList.add(statement);
             } else if (operationType.equals(SqlType.INSERT)

--- a/dinky-core/src/main/java/org/dinky/explainer/Explainer.java
+++ b/dinky-core/src/main/java/org/dinky/explainer/Explainer.java
@@ -102,58 +102,50 @@ public class Explainer {
         List<StatementParam> execute = new ArrayList<>();
         List<String> statementList = new ArrayList<>();
         List<UDF> udfList = new ArrayList<>();
-        label:
-        for (String item : statements) {
+                for (String item : statements) {
             String statement = executor.pretreatStatement(item);
             if (statement.isEmpty()) {
                 continue;
             }
             SqlType operationType = Operations.getOperationType(statement);
-            switch (operationType) {
-                case ADD:
-                    AddJarSqlParser.getAllFilePath(statement)
-                            .forEach(JarPathContextHolder::addOtherPlugins);
-                    DinkyClassLoaderContextHolder.get()
-                            .addURL(URLUtils.getURLs(JarPathContextHolder.getOtherPluginsFiles()));
+            if (operationType.equals(SqlType.ADD)) {
+                AddJarSqlParser.getAllFilePath(statement)
+                        .forEach(JarPathContextHolder::addOtherPlugins);
+                DinkyClassLoaderContextHolder.get()
+                        .addURL(URLUtils.getURLs(JarPathContextHolder.getOtherPluginsFiles()));
+            } else if (operationType.equals(SqlType.ADD_JAR)) {
+                ddl.add(new StatementParam(statement, operationType));
+                statementList.add(statement);
+            } else if (operationType.equals(SqlType.INSERT)
+                    || operationType.equals(SqlType.SELECT)
+                    || operationType.equals(SqlType.SHOW)
+                    || operationType.equals(SqlType.DESCRIBE)
+                    || operationType.equals(SqlType.DESC)) {
+                trans.add(new StatementParam(statement, operationType));
+                statementList.add(statement);
+                if (!useStatementSet) {
                     break;
-                case ADD_JAR:
-                    ddl.add(new StatementParam(statement, operationType));
-                    statementList.add(statement);
-                    break;
-                case INSERT:
-                case SELECT:
-                case SHOW:
-                case DESCRIBE:
-                case DESC:
-                    trans.add(new StatementParam(statement, operationType));
-                    statementList.add(statement);
-                    if (!useStatementSet) {
-                        break label;
-                    }
-                    break;
-                case EXECUTE:
-                    execute.add(new StatementParam(statement, operationType));
-                    break;
-                case WATCH:
-                    WatchStatementExplainer watchStatementExplainer =
-                            new WatchStatementExplainer(statement);
+                }
+            } else if (operationType.equals(SqlType.EXECUTE)) {
+                execute.add(new StatementParam(statement, operationType));
+            } else if (operationType.equals(SqlType.WATCH)) {
+                WatchStatementExplainer watchStatementExplainer =
+                        new WatchStatementExplainer(statement);
 
-                    String[] tableNames = watchStatementExplainer.getTableNames();
-                    for (String tableName : tableNames) {
-                        trans.add(
-                                new StatementParam(
-                                        WatchStatementExplainer.getCreateStatement(tableName),
-                                        SqlType.CTAS));
-                    }
-                    break;
-                default:
-                    UDF udf = UDFUtil.toUDF(statement);
-                    if (Asserts.isNotNull(udf)) {
-                        udfList.add(udf);
-                    }
-                    ddl.add(new StatementParam(statement, operationType));
-                    statementList.add(statement);
-                    break;
+                String[] tableNames = watchStatementExplainer.getTableNames();
+                for (String tableName : tableNames) {
+                    trans.add(
+                            new StatementParam(
+                                    WatchStatementExplainer.getCreateStatement(tableName),
+                                    SqlType.CTAS));
+                }
+            } else {
+                UDF udf = UDFUtil.toUDF(statement);
+                if (Asserts.isNotNull(udf)) {
+                    udfList.add(udf);
+                }
+                ddl.add(new StatementParam(statement, operationType));
+                statementList.add(statement);
             }
         }
         return new JobParam(statementList, ddl, trans, execute, CollUtil.removeNull(udfList));

--- a/dinky-executor/src/main/java/org/dinky/parser/SqlType.java
+++ b/dinky-executor/src/main/java/org/dinky/parser/SqlType.java
@@ -56,8 +56,8 @@ public enum SqlType {
     RESET("RESET", "^RESET.*"),
 
     EXECUTE("EXECUTE", "^EXECUTE.*"),
-
-    ADD("ADD", "^ADD.*"),
+    ADD_JAR("ADD_JAR", "^ADD\\s+JAR\\s+\\S+"),
+    ADD("ADD", "^ADD\\s+CUSTOMJAR\\s+\\S+"),
 
     WATCH("WATCH", "^WATCH.*"),
 

--- a/dinky-executor/src/main/java/org/dinky/parser/check/AddJarSqlParser.java
+++ b/dinky-executor/src/main/java/org/dinky/parser/check/AddJarSqlParser.java
@@ -36,7 +36,7 @@ import cn.hutool.core.util.StrUtil;
 /** @since 0.7.0 */
 public class AddJarSqlParser {
 
-    private static final String ADD_JAR = "(add\\s+jar)\\s+'(.*.jar)'";
+    private static final String ADD_JAR = "(add\\s+customjar)\\s+'(.*.jar)'";
     private static final Pattern ADD_JAR_PATTERN =
             Pattern.compile(ADD_JAR, Pattern.CASE_INSENSITIVE);
 

--- a/dinky-executor/src/main/java/org/dinky/trans/ddl/AddJarOperation.java
+++ b/dinky-executor/src/main/java/org/dinky/trans/ddl/AddJarOperation.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.api.TableResult;
 /** @since 0.7.0 */
 public class AddJarOperation extends AbstractOperation implements Operation {
 
-    private static final String KEY_WORD = "ADD JAR";
+    private static final String KEY_WORD = "ADD CUSTOMJAR";
 
     public AddJarOperation(String statement) {
         super(statement);

--- a/dinky-executor/src/test/java/org/dinky/parser/SqlTypeTest.java
+++ b/dinky-executor/src/test/java/org/dinky/parser/SqlTypeTest.java
@@ -52,7 +52,8 @@ class SqlTypeTest {
         test("SET...", SqlType.SET, true);
         test("RESET...", SqlType.RESET, true);
         test("EXECUTE...", SqlType.EXECUTE, true);
-        test("ADD...", SqlType.ADD, true);
+        test("ADD jar ...", SqlType.ADD_JAR, true);
+        test("ADD customjar ...", SqlType.ADD, true);
         test("WATCH...", SqlType.WATCH, true);
 
         String sql =

--- a/dinky-function/src/main/java/org/dinky/function/pool/UdfCodePool.java
+++ b/dinky-function/src/main/java/org/dinky/function/pool/UdfCodePool.java
@@ -48,9 +48,8 @@ public class UdfCodePool {
     public static UDF getUDF(String className) {
         UDF udf = CODE_POOL.get(className);
         if (udf == null) {
-            String error = StrUtil.format("class: {} is not exists!", className);
+            String error = StrUtil.format("class: {} is not exists!，maybe for add jar", className);
             log.warn(error);
-            //            throw new DinkyException(error);
         }
         return udf;
     }

--- a/dinky-function/src/main/java/org/dinky/function/pool/UdfCodePool.java
+++ b/dinky-function/src/main/java/org/dinky/function/pool/UdfCodePool.java
@@ -20,7 +20,6 @@
 package org.dinky.function.pool;
 
 import org.dinky.function.data.model.UDF;
-import org.dinky.process.exception.DinkyException;
 
 import java.util.List;
 import java.util.Map;
@@ -51,7 +50,7 @@ public class UdfCodePool {
         if (udf == null) {
             String error = StrUtil.format("class: {} is not exists!", className);
             log.warn(error);
-//            throw new DinkyException(error);
+            //            throw new DinkyException(error);
         }
         return udf;
     }

--- a/dinky-function/src/main/java/org/dinky/function/pool/UdfCodePool.java
+++ b/dinky-function/src/main/java/org/dinky/function/pool/UdfCodePool.java
@@ -50,8 +50,8 @@ public class UdfCodePool {
         UDF udf = CODE_POOL.get(className);
         if (udf == null) {
             String error = StrUtil.format("class: {} is not exists!", className);
-            log.error(error);
-            throw new DinkyException(error);
+            log.warn(error);
+//            throw new DinkyException(error);
         }
         return udf;
     }

--- a/dinky-function/src/main/java/org/dinky/function/util/UDFUtil.java
+++ b/dinky-function/src/main/java/org/dinky/function/util/UDFUtil.java
@@ -352,12 +352,14 @@ public class UDFUtil {
             }
 
             UDF udf = UdfCodePool.getUDF(className);
-            return UDF.builder()
-                    .name(udfName)
-                    .className(className)
-                    .code(udf.getCode())
-                    .functionLanguage(udf.getFunctionLanguage())
-                    .build();
+            if (udf != null) {
+                return UDF.builder()
+                        .name(udfName)
+                        .className(className)
+                        .code(udf.getCode())
+                        .functionLanguage(udf.getFunctionLanguage())
+                        .build();
+            }
         }
         return null;
     }


### PR DESCRIPTION
the `add jar` syntax in dinky cover the official `add jar`  now. they are not equivalent.