### PR TITLE
[Fix-1936][Client]: cdcsource convert value error

### DIFF
--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/cdc/AbstractSinkBuilder.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/cdc/AbstractSinkBuilder.java
@@ -343,6 +343,15 @@ public abstract class AbstractSinkBuilder implements SinkBuilder {
                                 .atZone(sinkTimeZone)
                                 .toLocalDateTime());
             } else if (value instanceof Long) {
+                // pgsql database timestamp is microsecond ,need transform to millisecond
+                // time is microsecond when time after 3000-01-01 00:00:00
+                // time is microsecond when time before 1000-01-01 00:00:00
+                if ((long) value > 32503651200000L || (long) value < -30610253143000L) {
+                    return TimestampData.fromLocalDateTime(
+                            Instant.ofEpochMilli((long) value / 1000)
+                                    .atZone(sinkTimeZone)
+                                    .toLocalDateTime());
+                }
                 return TimestampData.fromLocalDateTime(
                         Instant.ofEpochMilli((long) value).atZone(sinkTimeZone).toLocalDateTime());
             } else {
@@ -366,6 +375,12 @@ public abstract class AbstractSinkBuilder implements SinkBuilder {
         } else if (logicalType instanceof BigIntType) {
             if (value instanceof Integer) {
                 return ((Integer) value).longValue();
+            } else {
+                return value;
+            }
+        } else if (logicalType instanceof SmallIntType) {
+            if (value instanceof Number) {
+                return ((Number) value).shortValue();
             } else {
                 return value;
             }

--- a/dinky-client/dinky-client-1.15/src/main/java/org/dinky/cdc/AbstractSinkBuilder.java
+++ b/dinky-client/dinky-client-1.15/src/main/java/org/dinky/cdc/AbstractSinkBuilder.java
@@ -343,6 +343,15 @@ public abstract class AbstractSinkBuilder implements SinkBuilder {
                                 .atZone(sinkTimeZone)
                                 .toLocalDateTime());
             } else if (value instanceof Long) {
+                // pgsql database timestamp is microsecond ,need transform to millisecond
+                // time is microsecond when time after 3000-01-01 00:00:00
+                // time is microsecond when time before 1000-01-01 00:00:00
+                if ((long) value > 32503651200000L || (long) value < -30610253143000L) {
+                    return TimestampData.fromLocalDateTime(
+                            Instant.ofEpochMilli((long) value / 1000)
+                                    .atZone(sinkTimeZone)
+                                    .toLocalDateTime());
+                }
                 return TimestampData.fromLocalDateTime(
                         Instant.ofEpochMilli((long) value).atZone(sinkTimeZone).toLocalDateTime());
             } else {
@@ -366,6 +375,12 @@ public abstract class AbstractSinkBuilder implements SinkBuilder {
         } else if (logicalType instanceof BigIntType) {
             if (value instanceof Integer) {
                 return ((Integer) value).longValue();
+            } else {
+                return value;
+            }
+        } else if (logicalType instanceof SmallIntType) {
+            if (value instanceof Number) {
+                return ((Number) value).shortValue();
             } else {
                 return value;
             }


### PR DESCRIPTION
## Purpose of the pull request

Fix cdcsource task transform timestamp and SmallInt type error

## Brief change log

timestamp

- Timestamp type data adds an IF judgment.
- When the date is greater than 3000-01-01 or less than 1000-01-01, judge the current timestamp as microseconds, that is, time conversion

SmallInt

- Add a judgement on the SMALLINT data type

## Verify this pull request

This pull request is code cleanup without any test coverage.
