### PR TITLE
[Feature-1949][Client]feat: cdcsource add 'sink.table.rename' parameter

### DIFF
--- a/dinky-client/dinky-client-1.13/src/main/java/org/dinky/cdc/AbstractSinkBuilder.java
+++ b/dinky-client/dinky-client-1.13/src/main/java/org/dinky/cdc/AbstractSinkBuilder.java
@@ -392,8 +392,8 @@ public abstract class AbstractSinkBuilder implements SinkBuilder {
 
     public String getSinkSchemaName(Table table) {
         String schemaName = table.getSchema();
-        if (config.getSink().containsKey("sink.db")) {
-            schemaName = config.getSink().get("sink.db");
+        if (config.getSink().containsKey(FlinkCDCConfig.SINK_DB)) {
+            schemaName = config.getSink().get(FlinkCDCConfig.SINK_DB);
         }
         return schemaName;
     }
@@ -405,21 +405,24 @@ public abstract class AbstractSinkBuilder implements SinkBuilder {
                 tableName = table.getSchema() + "_" + tableName;
             }
         }
-        if (config.getSink().containsKey("table.prefix")) {
-            tableName = config.getSink().get("table.prefix") + tableName;
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_PREFIX)) {
+            tableName = config.getSink().get(FlinkCDCConfig.TABLE_PREFIX) + tableName;
         }
-        if (config.getSink().containsKey("table.suffix")) {
-            tableName = tableName + config.getSink().get("table.suffix");
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_SUFFIX)) {
+            tableName = tableName + config.getSink().get(FlinkCDCConfig.TABLE_SUFFIX);
         }
-        if (config.getSink().containsKey("table.lower")) {
-            if (Boolean.valueOf(config.getSink().get("table.lower"))) {
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_LOWER)) {
+            if (Boolean.valueOf(config.getSink().get(FlinkCDCConfig.TABLE_LOWER))) {
                 tableName = tableName.toLowerCase();
             }
         }
-        if (config.getSink().containsKey("table.upper")) {
-            if (Boolean.valueOf(config.getSink().get("table.upper"))) {
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_UPPER)) {
+            if (Boolean.valueOf(config.getSink().get(FlinkCDCConfig.TABLE_UPPER))) {
                 tableName = tableName.toUpperCase();
             }
+        }
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_RENAME)) {
+            tableName = config.getSink().get(FlinkCDCConfig.TABLE_RENAME);
         }
         return tableName;
     }

--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/cdc/AbstractSinkBuilder.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/cdc/AbstractSinkBuilder.java
@@ -398,8 +398,8 @@ public abstract class AbstractSinkBuilder implements SinkBuilder {
 
     public String getSinkSchemaName(Table table) {
         String schemaName = table.getSchema();
-        if (config.getSink().containsKey("sink.db")) {
-            schemaName = config.getSink().get("sink.db");
+        if (config.getSink().containsKey(FlinkCDCConfig.SINK_DB)) {
+            schemaName = config.getSink().get(FlinkCDCConfig.SINK_DB);
         }
         return schemaName;
     }
@@ -411,21 +411,24 @@ public abstract class AbstractSinkBuilder implements SinkBuilder {
                 tableName = table.getSchema() + "_" + tableName;
             }
         }
-        if (config.getSink().containsKey("table.prefix")) {
-            tableName = config.getSink().get("table.prefix") + tableName;
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_PREFIX)) {
+            tableName = config.getSink().get(FlinkCDCConfig.TABLE_PREFIX) + tableName;
         }
-        if (config.getSink().containsKey("table.suffix")) {
-            tableName = tableName + config.getSink().get("table.suffix");
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_SUFFIX)) {
+            tableName = tableName + config.getSink().get(FlinkCDCConfig.TABLE_SUFFIX);
         }
-        if (config.getSink().containsKey("table.lower")) {
-            if (Boolean.valueOf(config.getSink().get("table.lower"))) {
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_LOWER)) {
+            if (Boolean.valueOf(config.getSink().get(FlinkCDCConfig.TABLE_LOWER))) {
                 tableName = tableName.toLowerCase();
             }
         }
-        if (config.getSink().containsKey("table.upper")) {
-            if (Boolean.valueOf(config.getSink().get("table.upper"))) {
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_UPPER)) {
+            if (Boolean.valueOf(config.getSink().get(FlinkCDCConfig.TABLE_UPPER))) {
                 tableName = tableName.toUpperCase();
             }
+        }
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_RENAME)) {
+            tableName = config.getSink().get(FlinkCDCConfig.TABLE_RENAME);
         }
         return tableName;
     }

--- a/dinky-client/dinky-client-1.15/src/main/java/org/dinky/cdc/AbstractSinkBuilder.java
+++ b/dinky-client/dinky-client-1.15/src/main/java/org/dinky/cdc/AbstractSinkBuilder.java
@@ -399,8 +399,8 @@ public abstract class AbstractSinkBuilder implements SinkBuilder {
     @Override
     public String getSinkSchemaName(Table table) {
         String schemaName = table.getSchema();
-        if (config.getSink().containsKey("sink.db")) {
-            schemaName = config.getSink().get("sink.db");
+        if (config.getSink().containsKey(FlinkCDCConfig.SINK_DB)) {
+            schemaName = config.getSink().get(FlinkCDCConfig.SINK_DB);
         }
         return schemaName;
     }
@@ -413,21 +413,24 @@ public abstract class AbstractSinkBuilder implements SinkBuilder {
                 tableName = table.getSchema() + "_" + tableName;
             }
         }
-        if (config.getSink().containsKey("table.prefix")) {
-            tableName = config.getSink().get("table.prefix") + tableName;
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_PREFIX)) {
+            tableName = config.getSink().get(FlinkCDCConfig.TABLE_PREFIX) + tableName;
         }
-        if (config.getSink().containsKey("table.suffix")) {
-            tableName = tableName + config.getSink().get("table.suffix");
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_SUFFIX)) {
+            tableName = tableName + config.getSink().get(FlinkCDCConfig.TABLE_SUFFIX);
         }
-        if (config.getSink().containsKey("table.lower")) {
-            if (Boolean.valueOf(config.getSink().get("table.lower"))) {
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_LOWER)) {
+            if (Boolean.valueOf(config.getSink().get(FlinkCDCConfig.TABLE_LOWER))) {
                 tableName = tableName.toLowerCase();
             }
         }
-        if (config.getSink().containsKey("table.upper")) {
-            if (Boolean.valueOf(config.getSink().get("table.upper"))) {
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_UPPER)) {
+            if (Boolean.valueOf(config.getSink().get(FlinkCDCConfig.TABLE_UPPER))) {
                 tableName = tableName.toUpperCase();
             }
+        }
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_RENAME)) {
+            tableName = config.getSink().get(FlinkCDCConfig.TABLE_RENAME);
         }
         return tableName;
     }

--- a/dinky-client/dinky-client-1.16/src/main/java/org/dinky/cdc/AbstractSinkBuilder.java
+++ b/dinky-client/dinky-client-1.16/src/main/java/org/dinky/cdc/AbstractSinkBuilder.java
@@ -380,6 +380,9 @@ public abstract class AbstractSinkBuilder implements SinkBuilder {
                 tableName = tableName.toUpperCase();
             }
         }
+        if (config.getSink().containsKey(FlinkCDCConfig.TABLE_RENAME)) {
+            tableName = config.getSink().get(FlinkCDCConfig.TABLE_RENAME);
+        }
         return tableName;
     }
 

--- a/dinky-client/dinky-client-base/src/main/java/org/dinky/model/FlinkCDCConfig.java
+++ b/dinky-client/dinky-client-base/src/main/java/org/dinky/model/FlinkCDCConfig.java
@@ -36,6 +36,7 @@ public class FlinkCDCConfig {
     public static final String TABLE_SUFFIX = "table.suffix";
     public static final String TABLE_UPPER = "table.upper";
     public static final String TABLE_LOWER = "table.lower";
+    public static final String TABLE_RENAME = "table.rename";
     public static final String COLUMN_REPLACE_LINE_BREAK = "column.replace.line-break";
     public static final String TIMEZONE = "timezone";
     private String type;
@@ -137,6 +138,7 @@ public class FlinkCDCConfig {
             case TABLE_SUFFIX:
             case TABLE_UPPER:
             case TABLE_LOWER:
+            case TABLE_RENAME:
             case COLUMN_REPLACE_LINE_BREAK:
             case TIMEZONE:
                 return true;


### PR DESCRIPTION
## Purpose of the pull request

Issues: #1949 
cdcsource add `sink.table.rename` parameter, To complete the merging of partitioned tables (multiple tables) into a single table


## Brief change log

- `AbstractSinkBuilder.java` `getSinkTableName ` add `sink.table.rename`  logic
    * Flink-Client-1.13
    * Flink-Client-1.14
    * Flink-Client-1.15
    * Flink-Client-1.16
- Removes the magic value of the sink parameter
    * Flink-Client-1.13
    * Flink-Client-1.14
    * Flink-Client-1.15
- `FlinkCDCConfig.java` add  `sink.table.rename`  parameter

## Verify this pull request

This pull request is code cleanup without any test coverage.
