### PR TITLE
Fix #1958 (When PK do not declare at the table head, data misalignmen…

### DIFF
--- a/dlink-executor/src/main/java/com/dlink/executor/Executor.java
+++ b/dlink-executor/src/main/java/com/dlink/executor/Executor.java
@@ -199,14 +199,14 @@ public abstract class Executor {
 
         CustomTableEnvironment newestEnvironment = createCustomTableEnvironment();
         CustomTableEnvironmentContext.set(newestEnvironment);
-        if (stEnvironment != null) {
-            for (String catalog : stEnvironment.listCatalogs()) {
-                stEnvironment.getCatalog(catalog).ifPresent(t -> {
-                    newestEnvironment.getCatalogManager().unregisterCatalog(catalog, true);
-                    newestEnvironment.registerCatalog(catalog, t);
-                });
-            }
-        }
+        // if (stEnvironment != null) {
+        //     for (String catalog : stEnvironment.listCatalogs()) {
+        //         stEnvironment.getCatalog(catalog).ifPresent(t -> {
+        //             newestEnvironment.getCatalogManager().unregisterCatalog(catalog, true);
+        //             newestEnvironment.registerCatalog(catalog, t);
+        //         });
+        //     }
+        // }
         stEnvironment = newestEnvironment;
 
         final Configuration configuration = stEnvironment.getConfig().getConfiguration();

--- a/dlink-executor/src/main/java/com/dlink/trans/ddl/CreateCDCSourceOperation.java
+++ b/dlink-executor/src/main/java/com/dlink/trans/ddl/CreateCDCSourceOperation.java
@@ -112,8 +112,8 @@ public class CreateCDCSourceOperation extends AbstractOperation implements Opera
                     String schemaTableName = table.getSchemaTableNameList().get(0);
                     // 真实的表名
                     String tableName = schemaTableName.split("\\.")[1];
-                    table.setColumns(driver.listColumnsSortByPK(schemaName, tableName));
-                    table.setColumns(driver.listColumnsSortByPK(schemaName, table.getName()));
+                    table.setColumns(driver.listColumns(schemaName, tableName));
+                    table.setColumns(driver.listColumns(schemaName, table.getName()));
                     schemaList.add(schema);
 
                     if (null != sinkDriver) {
@@ -143,14 +143,14 @@ public class CreateCDCSourceOperation extends AbstractOperation implements Opera
                                 for (String tableReg : tableRegList) {
                                     if (table.getSchemaTableName().matches(tableReg.trim())
                                             && !schema.getTables().contains(Table.build(table.getName()))) {
-                                        table.setColumns(driver.listColumnsSortByPK(schemaName, table.getName()));
+                                        table.setColumns(driver.listColumns(schemaName, table.getName()));
                                         schema.getTables().add(table);
                                         schemaTableNameList.add(table.getSchemaTableName());
                                         break;
                                     }
                                 }
                             } else {
-                                table.setColumns(driver.listColumnsSortByPK(schemaName, table.getName()));
+                                table.setColumns(driver.listColumns(schemaName, table.getName()));
                                 schemaTableNameList.add(table.getSchemaTableName());
                                 schema.getTables().add(table);
                             }

--- a/dlink-metadata/dlink-metadata-doris/src/main/java/com/dlink/metadata/driver/DorisDriver.java
+++ b/dlink-metadata/dlink-metadata-doris/src/main/java/com/dlink/metadata/driver/DorisDriver.java
@@ -121,4 +121,10 @@ public class DorisDriver extends AbstractJdbcDriver {
         map.put("DATETIME", "TIMESTAMP");
         return map;
     }
+
+    @Override
+    public List<Column> listColumns(String schemaName, String tableName) {
+        // Doris 中声明为 Key 的列（可能是多个）必须顺序声明在建表语句头部，因此按 Key 对列重新排序
+        return listColumnsSortByPK(schemaName, tableName);
+    }
 }

--- a/dlink-metadata/dlink-metadata-doris/src/main/java/com/dlink/metadata/driver/DorisDriver.java
+++ b/dlink-metadata/dlink-metadata-doris/src/main/java/com/dlink/metadata/driver/DorisDriver.java
@@ -24,6 +24,7 @@ import com.dlink.metadata.convert.ITypeConvert;
 import com.dlink.metadata.query.DorisQuery;
 import com.dlink.metadata.query.IDBQuery;
 import com.dlink.metadata.result.JdbcSelectResult;
+import com.dlink.model.Column;
 import com.dlink.process.context.ProcessContextHolder;
 import com.dlink.process.model.ProcessEntity;
 import com.dlink.utils.LogUtil;

--- a/dlink-metadata/dlink-metadata-starrocks/src/main/java/com/dlink/metadata/driver/StarRocksDriver.java
+++ b/dlink-metadata/dlink-metadata-starrocks/src/main/java/com/dlink/metadata/driver/StarRocksDriver.java
@@ -107,4 +107,10 @@ public class StarRocksDriver extends AbstractJdbcDriver {
         map.put("DATETIME", "TIMESTAMP");
         return map;
     }
+
+    @Override
+    public List<Column> listColumns(String schemaName, String tableName) {
+        // StarRocks 中声明为 Key 的列（可能是多个）必须顺序声明在建表语句头部，因此按 Key 对列重新排序
+        return listColumnsSortByPK(schemaName, tableName);
+    }
 }

--- a/dlink-metadata/dlink-metadata-starrocks/src/main/java/com/dlink/metadata/driver/StarRocksDriver.java
+++ b/dlink-metadata/dlink-metadata-starrocks/src/main/java/com/dlink/metadata/driver/StarRocksDriver.java
@@ -24,6 +24,7 @@ import com.dlink.metadata.convert.StarRocksTypeConvert;
 import com.dlink.metadata.query.IDBQuery;
 import com.dlink.metadata.query.StarRocksQuery;
 import com.dlink.metadata.result.JdbcSelectResult;
+import com.dlink.model.Column;
 import com.dlink.utils.LogUtil;
 import com.dlink.utils.SqlUtil;
 


### PR DESCRIPTION
…t occurs after synchronizing data which caused by CDCSOURCE reorders table columns by PK)

## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
