### PR TITLE
[Fix-2168] sql generation bug fix

### DIFF
--- a/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/AbstractDriver.java
+++ b/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/AbstractDriver.java
@@ -107,7 +107,7 @@ public abstract class AbstractDriver implements Driver {
                 }
                 sb.append(String.format("`%s`  --  %s \n", columns.get(i).getName(), columnComment));
             } else {
-                sb.append(String.format("`%s` %\n", columns.get(i).getName()));
+                sb.append(String.format("`%s` \n", columns.get(i).getName()));
             }
         }
 


### PR DESCRIPTION
在类org.dinky.metadata.driver.AbstractDriver的getSqlSelect方法中有一个bug：sb.append(String.format("%s %\n", columns.get(i).getName()))，  后面那个%需要去掉