### PR TITLE
Enable backend paging

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/configure/MybatisPlusConfig.java
+++ b/dinky-admin/src/main/java/org/dinky/configure/MybatisPlusConfig.java
@@ -118,13 +118,8 @@ public class MybatisPlusConfig {
                 return !IGNORE_TABLE_NAMES.contains(tableName);
             }
         }));
-
+        interceptor.addInnerInterceptor(new PaginationInnerInterceptor());
         return interceptor;
-    }
-
-    @Bean
-    public PaginationInnerInterceptor paginationInterceptor() {
-        return new PaginationInnerInterceptor();
     }
 
     @Bean


### PR DESCRIPTION
The front-end paging is currently used, and the efficiency will be very low in the case of a large amount of data, so the back-end paging function is enabled. Taking the http://bigdata1:8888/api/jobInstance interface as an example, although we pass the paging parameters, the full amount is returned every time.

local dinky version:0.7.3


