### PR TITLE
[Fix][script]The statement field in the version table cannot be inserted as a long string. It should be changed to a long text type

### DIFF
--- a/dlink-doc/sql/dinky.sql
+++ b/dlink-doc/sql/dinky.sql
@@ -606,7 +606,7 @@ CREATE TABLE `dlink_task_version` (
                                       `task_id` int NOT NULL COMMENT 'task ID ',
                                       `tenant_id` int NOT NULL DEFAULT '1' COMMENT 'tenant id',
                                       `version_id` int NOT NULL COMMENT 'version ID ',
-                                      `statement` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci COMMENT 'flink sql statement',
+                                      `statement` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci COMMENT 'flink sql statement',
                                       `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT 'version name',
                                       `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT 'alisa',
                                       `dialect` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT 'dialect',


### PR DESCRIPTION
## Purpose of the pull request

dlink_task_version表的statement字段在插入大的字符串时报错，已于文末沟通提交该pr.

## Brief change log

在dlink-doc\sql\dinky.sql文件中，将statement字段类型由text改为longtext.
