### PR TITLE
[Fix-#2739] Fix bug that complete the missing path in auto.sh's CLASS_PATH

### DIFF
--- a/script/bin/auto.sh
+++ b/script/bin/auto.sh
@@ -5,7 +5,7 @@ FLINK_VERSION=${2:-1.18}
 JAR_NAME="dinky-admin"
 
 # Use FLINK_HOME:
-CLASS_PATH=".:./lib/*:config:./plugins/*:./customJar/*:./plugins/flink${FLINK_VERSION}/dinky/*:./plugins/flink${FLINK_VERSION}/*:./extends/flink${FLINK_VERSION}/dinky/*:./extends/flink${FLINK_VERSION}/*"
+CLASS_PATH=".:./lib/*:config:./extends/*:./plugins/*:./customJar/*:./plugins/flink${FLINK_VERSION}/dinky/*:./plugins/flink${FLINK_VERSION}/*:./extends/flink${FLINK_VERSION}/dinky/*:./extends/flink${FLINK_VERSION}/*"
 
 PID_FILE="dinky.pid"
 


### PR DESCRIPTION
## Purpose of the pull request

Fix bug #2739.

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
