### PR TITLE
[Fix-2806] [Flink] The job parameters are not effective when the set parameters key and value contain single quotes

### DIFF
--- a/dinky-client/dinky-client-base/src/main/java/org/dinky/trans/parse/SetSqlParseStrategy.java
+++ b/dinky-client/dinky-client-base/src/main/java/org/dinky/trans/parse/SetSqlParseStrategy.java
@@ -50,8 +50,8 @@ public class SetSqlParseStrategy extends AbstractRegexParseStrategy {
     public static Map<String, List<String>> getInfo(String statement) {
         // SET(\s+(\S+)\s*=(.*))?
         List<SqlSegment> segments = new ArrayList<>();
-        segments.add(new SqlSegment("(set)\\s+(.+)(\\s*=)", "[.]"));
-        segments.add(new SqlSegment("(=)\\s*(.*)($)", ","));
+        segments.add(new SqlSegment("(set)\\s+'?([^']+)'?(\\s*=)", "[.]"));
+        segments.add(new SqlSegment("(=)\\s*'?([^']+)'?($)", ","));
         return SqlSegmentUtil.splitSql2Segment(segments, statement);
     }
 

--- a/dinky-client/dinky-client-base/src/test/java/org/dinky/trans/ddl/CustomSetOperationTest.java
+++ b/dinky-client/dinky-client-base/src/test/java/org/dinky/trans/ddl/CustomSetOperationTest.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.trans.ddl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * CustomSetOperationTest
+ *
+ */
+public class CustomSetOperationTest {
+
+    private static final String SET_STATEMENT1 = "set execution.checkpointing.interval = 80000";
+    private static final String SET_STATEMENT2 = "SET 'execution.checkpointing.interval' = '80000'";
+    private static final String SET_STATEMENT3 = "SET 'execution.checkpointing.interval = 80000'";
+
+    @Test
+    public void setOperationTest() {
+        String expectKey = "execution.checkpointing.interval";
+        String expectValue = "80000";
+        CustomSetOperation customSetOperation1 = new CustomSetOperation(SET_STATEMENT1);
+        Assert.assertEquals(expectKey, customSetOperation1.getKey());
+        Assert.assertEquals(expectValue, customSetOperation1.getValue());
+        CustomSetOperation customSetOperation2 = new CustomSetOperation(SET_STATEMENT2);
+        Assert.assertEquals(expectKey, customSetOperation2.getKey());
+        Assert.assertEquals(expectValue, customSetOperation2.getValue());
+        CustomSetOperation customSetOperation3 = new CustomSetOperation(SET_STATEMENT3);
+        Assert.assertEquals(expectKey, customSetOperation3.getKey());
+        Assert.assertEquals(expectValue, customSetOperation3.getValue());
+    }
+}


### PR DESCRIPTION

## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
