### PR TITLE
[Fix-2811] Upgrade jmx_prometheus_javaagent to 0.20.0 to fix some CVE

### DIFF
--- a/dinky-admin/pom.xml
+++ b/dinky-admin/pom.xml
@@ -284,7 +284,7 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>jmx_prometheus_javaagent</artifactId>
-            <version>0.16.1</version>
+            <version>0.20.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.yaml</groupId>

--- a/script/bin/auto.sh
+++ b/script/bin/auto.sh
@@ -11,7 +11,7 @@ PID_FILE="dinky.pid"
 
 # JMX path
 APP_HOME="$(cd `dirname $0`; pwd)"
-JMX="-javaagent:$APP_HOME/lib/jmx_prometheus_javaagent-0.16.1.jar=10087:$APP_HOME/config/jmx/jmx_exporter_config.yaml"
+JMX="-javaagent:$APP_HOME/lib/jmx_prometheus_javaagent-0.20.0.jar=10087:$APP_HOME/config/jmx/jmx_exporter_config.yaml"
 
 # Check whether the pid path exists
 PID_PATH="$(cd "$(dirname "$0")";pwd)/run"


### PR DESCRIPTION
## Purpose of the pull request

Resolve #2811 

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
