### PR TITLE
support custom flink/hadoop config for cluster configuration and fix the type bug when auto regsiter session cluster

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/service/impl/ClusterInstanceServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/ClusterInstanceServiceImpl.java
@@ -231,7 +231,7 @@ public class ClusterInstanceServiceImpl extends SuperServiceImpl<ClusterInstance
                     gatewayResult.getWebURL().replace("http://", ""),
                     gatewayResult.getId(),
                     clusterCfg.getName() + "_" + LocalDateTime.now(),
-                    clusterCfg.getName() + LocalDateTime.now(),
+                    gatewayConfig.getType().getLongValue(),
                     id,
                     null));
         }

--- a/dinky-core/src/main/java/org/dinky/job/JobConfig.java
+++ b/dinky-core/src/main/java/org/dinky/job/JobConfig.java
@@ -225,6 +225,7 @@ public class JobConfig {
 
         gatewayConfig = GatewayConfig.build(config);
         gatewayConfig.setTaskId(getTaskId());
+        gatewayConfig.setType(GatewayType.get(getType()));
     }
 
     public void addGatewayConfig(Map<String, String> config) {

--- a/dinky-gateway/src/main/java/org/dinky/gateway/config/ClusterConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/config/ClusterConfig.java
@@ -19,13 +19,13 @@
 
 package org.dinky.gateway.config;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * ClusterConfig
@@ -58,10 +58,7 @@ public class ClusterConfig {
             notes = "Path to the YARN configuration file")
     private String hadoopConfigPath;
 
-    @ApiModelProperty(
-            value = "Custom Hadoop Config",
-            dataType = "Configuration",
-            notes = "Custom hadoop config")
+    @ApiModelProperty(value = "Custom Hadoop Config", dataType = "Configuration", notes = "Custom hadoop config")
     private Map<String, String> customHadoopConfig = new HashMap<>();
 
     @ApiModelProperty(

--- a/dinky-gateway/src/main/java/org/dinky/gateway/config/ClusterConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/config/ClusterConfig.java
@@ -19,7 +19,11 @@
 
 package org.dinky.gateway.config;
 
+import org.dinky.gateway.model.CustomConfig;
+
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import io.swagger.annotations.ApiModel;
@@ -58,8 +62,20 @@ public class ClusterConfig {
             notes = "Path to the YARN configuration file")
     private String hadoopConfigPath;
 
-    @ApiModelProperty(value = "Custom Hadoop Config", dataType = "Configuration", notes = "Custom hadoop config")
-    private Map<String, String> customHadoopConfig = new HashMap<>();
+    @ApiModelProperty(
+            value = "Additional hadoop configuration properties",
+            dataType = "List",
+            example = "[{\"name\":\"key1\",\"value\":\"value1\"}, {\"name\":\"key2\",\"value\":\"value2\"}]",
+            notes = "Additional hadoop configuration properties for the job on web page")
+    private List<CustomConfig> hadoopConfigList = new ArrayList<>();
+
+    @ApiModelProperty(
+            value = "Additional hadoop configuration properties",
+            dataType = "Map",
+            example = "{\"key1\":\"value1\",\"key2\":\"value2\"}",
+            notes = "Additional hadoop configuration properties for the job, invisible on web page",
+            hidden = true)
+    private Map<String, String> hadoopConfigMap = new HashMap<>();
 
     @ApiModelProperty(
             value = "YARN application ID",

--- a/dinky-gateway/src/main/java/org/dinky/gateway/config/ClusterConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/config/ClusterConfig.java
@@ -24,6 +24,9 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * ClusterConfig
  *
@@ -54,6 +57,12 @@ public class ClusterConfig {
             example = "/etc/hadoop/conf/yarn-site.xml",
             notes = "Path to the YARN configuration file")
     private String hadoopConfigPath;
+
+    @ApiModelProperty(
+            value = "Custom Hadoop Config",
+            dataType = "Configuration",
+            notes = "Custom hadoop config")
+    private Map<String, String> customHadoopConfig = new HashMap<>();
 
     @ApiModelProperty(
             value = "YARN application ID",

--- a/dinky-gateway/src/main/java/org/dinky/gateway/config/FlinkConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/config/FlinkConfig.java
@@ -23,9 +23,7 @@ import org.dinky.assertion.Asserts;
 import org.dinky.gateway.enums.ActionType;
 import org.dinky.gateway.enums.SavePointType;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 

--- a/dinky-gateway/src/main/java/org/dinky/gateway/config/FlinkConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/config/FlinkConfig.java
@@ -22,8 +22,11 @@ package org.dinky.gateway.config;
 import org.dinky.assertion.Asserts;
 import org.dinky.gateway.enums.ActionType;
 import org.dinky.gateway.enums.SavePointType;
+import org.dinky.gateway.model.CustomConfig;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -90,9 +93,16 @@ public class FlinkConfig {
 
     @ApiModelProperty(
             value = "Additional configuration properties",
+            dataType = "List",
+            example = "[{\"name\":\"key1\",\"value\":\"value1\"}, {\"name\":\"key2\",\"value\":\"value2\"}]",
+            notes = "Additional configuration properties for the job on web page")
+    private List<CustomConfig> flinkConfigList = new ArrayList<>();
+
+    @ApiModelProperty(
+            value = "Additional configuration properties",
             dataType = "Map",
             example = "{\"key1\":\"value1\",\"key2\":\"value2\"}",
-            notes = "Additional configuration properties for the job")
+            notes = "Fixed configuration properties for the job on web page")
     private Map<String, String> configuration = new HashMap<>();
 
     private static final ObjectMapper mapper = new ObjectMapper();

--- a/dinky-gateway/src/main/java/org/dinky/gateway/config/FlinkConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/config/FlinkConfig.java
@@ -97,13 +97,6 @@ public class FlinkConfig {
             notes = "Additional configuration properties for the job")
     private Map<String, String> configuration = new HashMap<>();
 
-    @ApiModelProperty(
-            value = "List of Flink configuration properties",
-            dataType = "List<Map<String, String>>",
-            example = "[{\"key\":\"value\"},{\"key2\":\"value2\"}]",
-            notes = "List of Flink configuration properties")
-    private List<Map<String, String>> flinkConfigList = new ArrayList<>();
-
     private static final ObjectMapper mapper = new ObjectMapper();
 
     public static final String DEFAULT_SAVEPOINT_PREFIX = "hdfs:///flink/savepoints/";

--- a/dinky-gateway/src/main/java/org/dinky/gateway/config/GatewayConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/config/GatewayConfig.java
@@ -19,11 +19,9 @@
 
 package org.dinky.gateway.config;
 
-import org.dinky.assertion.Asserts;
 import org.dinky.gateway.enums.GatewayType;
+import org.dinky.gateway.model.CustomConfig;
 import org.dinky.gateway.model.FlinkClusterConfig;
-
-import java.util.Map;
 
 import cn.hutool.core.bean.BeanUtil;
 import cn.hutool.core.lang.Assert;
@@ -88,12 +86,16 @@ public class GatewayConfig {
         Assert.notNull(config);
         GatewayConfig gatewayConfig = new GatewayConfig();
         BeanUtil.copyProperties(config, gatewayConfig);
-        for (Map<String, String> item : gatewayConfig.getFlinkConfig().getFlinkConfigList()) {
-            if (Asserts.isNotNull(item)) {
-                Assert.notNull(item.get("name"), "Custer config has null item");
-                Assert.notNull(item.get("value"), "Custer config has null item");
-                gatewayConfig.getFlinkConfig().getConfiguration().put(item.get("name"), item.get("value"));
-            }
+        for (CustomConfig customConfig : config.getFlinkConfigList()) {
+            Assert.notNull(customConfig.getName(), "Custom flink config has null key");
+            Assert.notNull(customConfig.getValue(), "Custom flink config has null value");
+            gatewayConfig.getFlinkConfig().getConfiguration().put(customConfig.getName(), customConfig.getValue());
+        }
+        for (CustomConfig customConfig : config.getHadoopConfigList()) {
+            Assert.notNull(customConfig.getName(), "Custom hadoop config has null key");
+            Assert.notNull(customConfig.getValue(), "Custom hadoop config has null value");
+            gatewayConfig.getClusterConfig().getCustomHadoopConfig()
+                    .put(customConfig.getName(), customConfig.getValue());
         }
         return gatewayConfig;
     }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/config/GatewayConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/config/GatewayConfig.java
@@ -94,7 +94,9 @@ public class GatewayConfig {
         for (CustomConfig customConfig : config.getHadoopConfigList()) {
             Assert.notNull(customConfig.getName(), "Custom hadoop config has null key");
             Assert.notNull(customConfig.getValue(), "Custom hadoop config has null value");
-            gatewayConfig.getClusterConfig().getCustomHadoopConfig()
+            gatewayConfig
+                    .getClusterConfig()
+                    .getCustomHadoopConfig()
                     .put(customConfig.getName(), customConfig.getValue());
         }
         return gatewayConfig;

--- a/dinky-gateway/src/main/java/org/dinky/gateway/config/GatewayConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/config/GatewayConfig.java
@@ -86,18 +86,10 @@ public class GatewayConfig {
         Assert.notNull(config);
         GatewayConfig gatewayConfig = new GatewayConfig();
         BeanUtil.copyProperties(config, gatewayConfig);
-        for (CustomConfig customConfig : config.getFlinkConfigList()) {
+        for (CustomConfig customConfig : config.getFlinkConfig().getFlinkConfigList()) {
             Assert.notNull(customConfig.getName(), "Custom flink config has null key");
             Assert.notNull(customConfig.getValue(), "Custom flink config has null value");
             gatewayConfig.getFlinkConfig().getConfiguration().put(customConfig.getName(), customConfig.getValue());
-        }
-        for (CustomConfig customConfig : config.getHadoopConfigList()) {
-            Assert.notNull(customConfig.getName(), "Custom hadoop config has null key");
-            Assert.notNull(customConfig.getValue(), "Custom hadoop config has null value");
-            gatewayConfig
-                    .getClusterConfig()
-                    .getCustomHadoopConfig()
-                    .put(customConfig.getName(), customConfig.getValue());
         }
         return gatewayConfig;
     }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/model/CustomConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/model/CustomConfig.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.gateway.model;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ApiModel(value = "CustomConfig", description = "Custom config of name-value model")
+public class CustomConfig {
+    @ApiModelProperty(
+            value = "Custom Config Name",
+            dataType = "String",
+            notes = "The name of custom config")
+    private String name;
+
+    @ApiModelProperty(
+            value = "Custom Config Value",
+            dataType = "String",
+            notes = "The value of custom config")
+    private String value;
+}

--- a/dinky-gateway/src/main/java/org/dinky/gateway/model/CustomConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/model/CustomConfig.java
@@ -28,15 +28,9 @@ import lombok.Setter;
 @Setter
 @ApiModel(value = "CustomConfig", description = "Custom config of name-value model")
 public class CustomConfig {
-    @ApiModelProperty(
-            value = "Custom Config Name",
-            dataType = "String",
-            notes = "The name of custom config")
+    @ApiModelProperty(value = "Custom Config Name", dataType = "String", notes = "The name of custom config")
     private String name;
 
-    @ApiModelProperty(
-            value = "Custom Config Value",
-            dataType = "String",
-            notes = "The value of custom config")
+    @ApiModelProperty(value = "Custom Config Value", dataType = "String", notes = "The value of custom config")
     private String value;
 }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/model/FlinkClusterConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/model/FlinkClusterConfig.java
@@ -25,8 +25,6 @@ import org.dinky.gateway.config.FlinkConfig;
 import org.dinky.gateway.config.K8sConfig;
 import org.dinky.gateway.enums.GatewayType;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import io.swagger.annotations.ApiModel;
@@ -60,22 +58,10 @@ public class FlinkClusterConfig {
     private FlinkConfig flinkConfig;
 
     @ApiModelProperty(
-            value = "Custom Flink Configuration",
-            dataType = "List",
-            notes = "Custom configuration settings for the Flink cluster")
-    private List<CustomConfig> flinkConfigList = new ArrayList<>();
-
-    @ApiModelProperty(
             value = "Application Configuration",
             dataType = "AppConfig",
             notes = "Configuration settings for the application")
     private AppConfig appConfig = new AppConfig();
-
-    @ApiModelProperty(
-            value = "Custom Hadoop Configuration",
-            dataType = "List",
-            notes = "Custom configuration settings for Hadoop")
-    private List<CustomConfig> hadoopConfigList = new ArrayList<>();
 
     @ApiModelProperty(
             value = "Kubernetes Configuration",

--- a/dinky-gateway/src/main/java/org/dinky/gateway/model/FlinkClusterConfig.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/model/FlinkClusterConfig.java
@@ -25,6 +25,8 @@ import org.dinky.gateway.config.FlinkConfig;
 import org.dinky.gateway.config.K8sConfig;
 import org.dinky.gateway.enums.GatewayType;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import io.swagger.annotations.ApiModel;
@@ -58,10 +60,22 @@ public class FlinkClusterConfig {
     private FlinkConfig flinkConfig;
 
     @ApiModelProperty(
+            value = "Custom Flink Configuration",
+            dataType = "List",
+            notes = "Custom configuration settings for the Flink cluster")
+    private List<CustomConfig> flinkConfigList = new ArrayList<>();
+
+    @ApiModelProperty(
             value = "Application Configuration",
             dataType = "AppConfig",
             notes = "Configuration settings for the application")
     private AppConfig appConfig = new AppConfig();
+
+    @ApiModelProperty(
+            value = "Custom Hadoop Configuration",
+            dataType = "List",
+            notes = "Custom configuration settings for Hadoop")
+    private List<CustomConfig> hadoopConfigList = new ArrayList<>();
 
     @ApiModelProperty(
             value = "Kubernetes Configuration",

--- a/dinky-gateway/src/main/java/org/dinky/gateway/yarn/YarnGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/yarn/YarnGateway.java
@@ -19,7 +19,6 @@
 
 package org.dinky.gateway.yarn;
 
-import cn.hutool.core.collection.CollectionUtil;
 import org.dinky.assertion.Asserts;
 import org.dinky.context.FlinkUdfPathContextHolder;
 import org.dinky.data.enums.JobStatus;
@@ -60,11 +59,16 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import cn.hutool.core.collection.CollUtil;
+import cn.hutool.core.collection.CollectionUtil;
 import cn.hutool.core.io.FileUtil;
 
 public abstract class YarnGateway extends AbstractGateway {
@@ -72,10 +76,10 @@ public abstract class YarnGateway extends AbstractGateway {
     public static final String HADOOP_CONFIG = "fs.hdfs.hadoopconf";
 
     protected YarnConfiguration yarnConfiguration;
+
     protected YarnClient yarnClient;
 
-    public YarnGateway() {
-    }
+    public YarnGateway() {}
 
     public YarnGateway(GatewayConfig config) {
         super(config);

--- a/dinky-gateway/src/main/java/org/dinky/gateway/yarn/YarnGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/yarn/YarnGateway.java
@@ -29,6 +29,7 @@ import org.dinky.gateway.config.GatewayConfig;
 import org.dinky.gateway.enums.ActionType;
 import org.dinky.gateway.enums.SavePointType;
 import org.dinky.gateway.exception.GatewayException;
+import org.dinky.gateway.model.CustomConfig;
 import org.dinky.gateway.result.SavePointResult;
 import org.dinky.gateway.result.TestResult;
 
@@ -62,7 +63,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -70,6 +71,7 @@ import java.util.stream.Collectors;
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.collection.CollectionUtil;
 import cn.hutool.core.io.FileUtil;
+import cn.hutool.core.lang.Assert;
 
 public abstract class YarnGateway extends AbstractGateway {
 
@@ -137,11 +139,12 @@ public abstract class YarnGateway extends AbstractGateway {
         yarnConfiguration.addResource(getYanConfigFilePath("core-site.xml"));
         yarnConfiguration.addResource(getYanConfigFilePath("hdfs-site.xml"));
 
-        Map<String, String> customHadoopConfig = clusterConfig.getCustomHadoopConfig();
-        if (CollectionUtil.isNotEmpty(customHadoopConfig)) {
-            customHadoopConfig.forEach((key, value) -> {
-                logger.debug("Custom hadoop config: {} = {}", key, value);
-                yarnConfiguration.set(key, value);
+        List<CustomConfig> hadoopConfigList = clusterConfig.getHadoopConfigList();
+        if (CollectionUtil.isNotEmpty(hadoopConfigList)) {
+            hadoopConfigList.forEach((customConfig) -> {
+                Assert.notNull(customConfig.getName(), "Custom hadoop config has null key");
+                Assert.notNull(customConfig.getValue(), "Custom hadoop config has null value");
+                yarnConfiguration.set(customConfig.getName(), customConfig.getValue());
             });
         }
 

--- a/dinky-gateway/src/test/java/org/dinky/gateway/model/FlinkClusterConfigTest.java
+++ b/dinky-gateway/src/test/java/org/dinky/gateway/model/FlinkClusterConfigTest.java
@@ -1,0 +1,75 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.gateway.model;
+
+import org.assertj.core.api.Assertions;
+import org.dinky.gateway.config.ClusterConfig;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.List;
+
+public class FlinkClusterConfigTest {
+
+    @Ignore
+    @Test
+    public void testParseCustomConfig() throws IOException {
+        String clusterConfigJson = "{\n" +
+                "        \"clusterConfig\":{\n" +
+                "            \"hadoopConfigPath\":\"/opt/dinky-resources/hadoopConfDir\",\n" +
+                "            \"flinkLibPath\":\"hdfs:///flink/flink1.14-lib\",\n" +
+                "            \"flinkConfigPath\":\"/opt/flink/conf\"\n" +
+                "        },\n" +
+                "        \"hadoopConfigList\":[\n" +
+                "            {\n" +
+                "                \"name\":\"yarn.timeline-service.enabled\",\n" +
+                "                \"value\":\"false\"\n" +
+                "            }\n" +
+                "        ],\n" +
+                "        \"flinkConfigList\":[\n" +
+                "            {\n" +
+                "                \"name\":\"yarn.application.queue\",\n" +
+                "                \"value\":\"prod\"\n" +
+                "            }\n" +
+                "        ],\n" +
+                "        \"flinkConfig\":{\n" +
+                "            \"configuration\":{\n" +
+                "                \"jobmanager.memory.process.size\":\"2G\",\n" +
+                "                \"taskmanager.memory.process.size\":\"2G\",\n" +
+                "                \"taskmanager.memory.framework.heap.size\":\"1G\",\n" +
+                "                \"taskmanager.numberOfTaskSlots\":\"2\",\n" +
+                "                \"state.savepoints.dir\":\"hdfs:///flink/savepoint\",\n" +
+                "                \"state.checkpoints.dir\":\"hdfs:///flink/checkpoint\"\n" +
+                "            }\n" +
+                "        },\n" +
+                "        \"appConfig\":{\n" +
+                "            \"userJarPath\":\"hdfs:///flink/dinky/jar/dinky-app-1.14-1.0.0-rc1-jar-with-dependencies.jar\"\n" +
+                "        }\n" +
+                "    }";
+        ObjectMapper objectMapper = new ObjectMapper();
+        FlinkClusterConfig clusterConfig = objectMapper.readValue(clusterConfigJson, FlinkClusterConfig.class);
+        List<CustomConfig> flinkConfigList = clusterConfig.getFlinkConfigList();
+        List<CustomConfig> hadoopConfigList = clusterConfig.getHadoopConfigList();
+        Assertions.assertThat(flinkConfigList.get(0).getName()).isEqualTo("yarn.application.queue");
+        Assertions.assertThat(hadoopConfigList.get(0).getName()).isEqualTo("yarn.timeline-service.enabled");
+    }
+}

--- a/dinky-gateway/src/test/java/org/dinky/gateway/model/FlinkClusterConfigTest.java
+++ b/dinky-gateway/src/test/java/org/dinky/gateway/model/FlinkClusterConfigTest.java
@@ -33,41 +33,42 @@ public class FlinkClusterConfigTest {
     @Test
     public void testParseCustomConfig() throws IOException {
 
-        String clusterConfigJson = "{\n" + "        \"clusterConfig\":{\n"
-                + "            \"hadoopConfigPath\":\"/opt/dinky-resources/hadoopConfDir\",\n"
-                + "            \"flinkLibPath\":\"hdfs:///flink/flink1.14-lib\",\n"
-                + "            \"flinkConfigPath\":\"/opt/flink/conf\"\n"
-                + "        },\n"
+        String clusterConfigJson = "{\n" + "    \"clusterConfig\":{\n"
+                + "        \"hadoopConfigPath\":\"/opt/dinky-resources/hadoopConfDir\",\n"
+                + "        \"flinkLibPath\":\"hdfs:///flink/flink1.14-lib\",\n"
+                + "        \"flinkConfigPath\":\"/opt/flink/conf\",\n"
                 + "        \"hadoopConfigList\":[\n"
                 + "            {\n"
                 + "                \"name\":\"yarn.timeline-service.enabled\",\n"
                 + "                \"value\":\"false\"\n"
                 + "            }\n"
-                + "        ],\n"
+                + "        ]\n"
+                + "    },\n"
+                + "    \"flinkConfig\":{\n"
+                + "        \"configuration\":{\n"
+                + "            \"jobmanager.memory.process.size\":\"2G\",\n"
+                + "            \"taskmanager.memory.process.size\":\"2G\",\n"
+                + "            \"taskmanager.memory.framework.heap.size\":\"1G\",\n"
+                + "            \"taskmanager.numberOfTaskSlots\":\"2\",\n"
+                + "            \"state.savepoints.dir\":\"hdfs:///flink/savepoint\",\n"
+                + "            \"state.checkpoints.dir\":\"hdfs:///flink/checkpoint\"\n"
+                + "        },\n"
                 + "        \"flinkConfigList\":[\n"
                 + "            {\n"
                 + "                \"name\":\"yarn.application.queue\",\n"
                 + "                \"value\":\"prod\"\n"
                 + "            }\n"
-                + "        ],\n"
-                + "        \"flinkConfig\":{\n"
-                + "            \"configuration\":{\n"
-                + "                \"jobmanager.memory.process.size\":\"2G\",\n"
-                + "                \"taskmanager.memory.process.size\":\"2G\",\n"
-                + "                \"taskmanager.memory.framework.heap.size\":\"1G\",\n"
-                + "                \"taskmanager.numberOfTaskSlots\":\"2\",\n"
-                + "                \"state.savepoints.dir\":\"hdfs:///flink/savepoint\",\n"
-                + "                \"state.checkpoints.dir\":\"hdfs:///flink/checkpoint\"\n"
-                + "            }\n"
-                + "        },\n"
-                + "        \"appConfig\":{\n"
-                + "            \"userJarPath\":\"hdfs:///flink/dinky/jar/dinky-app-1.14-1.0.0-rc1-jar-with-dependencies.jar\"\n"
-                + "        }\n"
-                + "    }";
+                + "        ]\n"
+                + "    },\n"
+                + "    \"appConfig\":{\n"
+                + "        \"userJarPath\":\"hdfs:///flink/dinky/jar/dinky-app-1.14-1.0.0-rc1-jar-with-dependencies.jar\"\n"
+                + "    }\n"
+                + "}";
         ObjectMapper objectMapper = new ObjectMapper();
-        FlinkClusterConfig clusterConfig = objectMapper.readValue(clusterConfigJson, FlinkClusterConfig.class);
-        List<CustomConfig> flinkConfigList = clusterConfig.getFlinkConfigList();
-        List<CustomConfig> hadoopConfigList = clusterConfig.getHadoopConfigList();
+        FlinkClusterConfig flinkClusterConfig = objectMapper.readValue(clusterConfigJson, FlinkClusterConfig.class);
+        List<CustomConfig> flinkConfigList = flinkClusterConfig.getFlinkConfig().getFlinkConfigList();
+        List<CustomConfig> hadoopConfigList =
+                flinkClusterConfig.getClusterConfig().getHadoopConfigList();
         Assertions.assertThat(flinkConfigList.get(0).getName()).isEqualTo("yarn.application.queue");
         Assertions.assertThat(hadoopConfigList.get(0).getName()).isEqualTo("yarn.timeline-service.enabled");
     }

--- a/dinky-gateway/src/test/java/org/dinky/gateway/model/FlinkClusterConfigTest.java
+++ b/dinky-gateway/src/test/java/org/dinky/gateway/model/FlinkClusterConfigTest.java
@@ -19,52 +19,51 @@
 
 package org.dinky.gateway.model;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.assertj.core.api.Assertions;
-import org.dinky.gateway.config.ClusterConfig;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.io.IOException;
-import java.util.List;
 
 public class FlinkClusterConfigTest {
 
     @Ignore
     @Test
     public void testParseCustomConfig() throws IOException {
-        String clusterConfigJson = "{\n" +
-                "        \"clusterConfig\":{\n" +
-                "            \"hadoopConfigPath\":\"/opt/dinky-resources/hadoopConfDir\",\n" +
-                "            \"flinkLibPath\":\"hdfs:///flink/flink1.14-lib\",\n" +
-                "            \"flinkConfigPath\":\"/opt/flink/conf\"\n" +
-                "        },\n" +
-                "        \"hadoopConfigList\":[\n" +
-                "            {\n" +
-                "                \"name\":\"yarn.timeline-service.enabled\",\n" +
-                "                \"value\":\"false\"\n" +
-                "            }\n" +
-                "        ],\n" +
-                "        \"flinkConfigList\":[\n" +
-                "            {\n" +
-                "                \"name\":\"yarn.application.queue\",\n" +
-                "                \"value\":\"prod\"\n" +
-                "            }\n" +
-                "        ],\n" +
-                "        \"flinkConfig\":{\n" +
-                "            \"configuration\":{\n" +
-                "                \"jobmanager.memory.process.size\":\"2G\",\n" +
-                "                \"taskmanager.memory.process.size\":\"2G\",\n" +
-                "                \"taskmanager.memory.framework.heap.size\":\"1G\",\n" +
-                "                \"taskmanager.numberOfTaskSlots\":\"2\",\n" +
-                "                \"state.savepoints.dir\":\"hdfs:///flink/savepoint\",\n" +
-                "                \"state.checkpoints.dir\":\"hdfs:///flink/checkpoint\"\n" +
-                "            }\n" +
-                "        },\n" +
-                "        \"appConfig\":{\n" +
-                "            \"userJarPath\":\"hdfs:///flink/dinky/jar/dinky-app-1.14-1.0.0-rc1-jar-with-dependencies.jar\"\n" +
-                "        }\n" +
-                "    }";
+
+        String clusterConfigJson = "{\n" + "        \"clusterConfig\":{\n"
+                + "            \"hadoopConfigPath\":\"/opt/dinky-resources/hadoopConfDir\",\n"
+                + "            \"flinkLibPath\":\"hdfs:///flink/flink1.14-lib\",\n"
+                + "            \"flinkConfigPath\":\"/opt/flink/conf\"\n"
+                + "        },\n"
+                + "        \"hadoopConfigList\":[\n"
+                + "            {\n"
+                + "                \"name\":\"yarn.timeline-service.enabled\",\n"
+                + "                \"value\":\"false\"\n"
+                + "            }\n"
+                + "        ],\n"
+                + "        \"flinkConfigList\":[\n"
+                + "            {\n"
+                + "                \"name\":\"yarn.application.queue\",\n"
+                + "                \"value\":\"prod\"\n"
+                + "            }\n"
+                + "        ],\n"
+                + "        \"flinkConfig\":{\n"
+                + "            \"configuration\":{\n"
+                + "                \"jobmanager.memory.process.size\":\"2G\",\n"
+                + "                \"taskmanager.memory.process.size\":\"2G\",\n"
+                + "                \"taskmanager.memory.framework.heap.size\":\"1G\",\n"
+                + "                \"taskmanager.numberOfTaskSlots\":\"2\",\n"
+                + "                \"state.savepoints.dir\":\"hdfs:///flink/savepoint\",\n"
+                + "                \"state.checkpoints.dir\":\"hdfs:///flink/checkpoint\"\n"
+                + "            }\n"
+                + "        },\n"
+                + "        \"appConfig\":{\n"
+                + "            \"userJarPath\":\"hdfs:///flink/dinky/jar/dinky-app-1.14-1.0.0-rc1-jar-with-dependencies.jar\"\n"
+                + "        }\n"
+                + "    }";
         ObjectMapper objectMapper = new ObjectMapper();
         FlinkClusterConfig clusterConfig = objectMapper.readValue(clusterConfigJson, FlinkClusterConfig.class);
         List<CustomConfig> flinkConfigList = clusterConfig.getFlinkConfigList();

--- a/dinky-web/src/pages/RegCenter/Cluster/Configuration/components/ConfigurationModal/ConfigurationForm/YarnConfig/index.tsx
+++ b/dinky-web/src/pages/RegCenter/Cluster/Configuration/components/ConfigurationModal/ConfigurationForm/YarnConfig/index.tsx
@@ -54,7 +54,7 @@ const YarnConfig = (props: { flinkConfigOptions: DefaultOptionType[] }) => {
           </ProFormGroup>
           <Divider>{l('rc.cc.hadoop.defineConfig')}</Divider>
           <ProFormList
-            name={['config', 'hadoopConfigList']}
+            name={['config', 'clusterConfig', 'hadoopConfigList']}
             copyIconProps={false}
             deleteIconProps={{
               tooltipText: l('rc.cc.deleteConfig')
@@ -104,7 +104,7 @@ const YarnConfig = (props: { flinkConfigOptions: DefaultOptionType[] }) => {
 
           <Divider>{l('rc.cc.flink.defineConfig')}</Divider>
           <ProFormList
-            name={['config', 'flinkConfigList']}
+            name={['config', 'flinkConfig', 'flinkConfigList']}
             copyIconProps={false}
             deleteIconProps={{
               tooltipText: l('rc.cc.deleteConfig')


### PR DESCRIPTION
changes:
### 1. save and show the custom flink/hadoop config, like below:
![图片](https://github.com/DataLinkDC/dinky/assets/42764848/7f9b4bcc-3180-4a1d-b4dd-285876b36e54)
I created a name-value class;
### 2. fix the cluster type when registering session cluster after created on page:
where to start a yarn-session cluster:
![图片](https://github.com/DataLinkDC/dinky/assets/42764848/b0079e4c-9dc1-4a39-b175-f34d5e683342)
the auto registered cluster info:
![图片](https://github.com/DataLinkDC/dinky/assets/42764848/09f884e8-c71c-4109-88d1-e9915c9bab4e)
### 3. fix the gateway type setting:
what the error i meet before i fix:
a flink-sql job on yarn per-job submit:
```text
[dinky] 2024-01-03 16:16:32 CST WARN  org.dinky.utils.FlinkConfigOptionsUtils 81 loadOptionsByClassName - get config option error, class not found: org.apache.flink.configuration.YarnConfigOptions
[dinky] 2024-01-03 16:16:32 CST WARN  org.dinky.context.ConsoleContextHolder 86 getProcess - Get process FlinkSubmit/6 failed, maybe not exits
[dinky] 2024-01-03 16:16:32 CST WARN  org.dinky.utils.FlinkConfigOptionsUtils 81 loadOptionsByClassName - get config option error, class not found: org.apache.flink.configuration.KubernetesConfigOptions
[dinky] 2024-01-03 16:16:32 CST WARN  org.dinky.utils.FlinkConfigOptionsUtils 81 loadOptionsByClassName - get config option error, class not found: org.apache.flink.configuration.YarnConfigOptions
[dinky] 2024-01-03 16:16:32 CST WARN  org.dinky.utils.FlinkConfigOptionsUtils 81 loadOptionsByClassName - get config option error, class not found: org.apache.flink.configuration.KubernetesConfigOptions
[dinky] 2024-01-03 16:16:32 CST WARN  org.dinky.utils.FlinkConfigOptionsUtils 81 loadOptionsByClassName - get config option error, class not found: org.apache.flink.configuration.YarnConfigOptions
[dinky] 2024-01-03 16:16:33 CST WARN  org.dinky.utils.FlinkConfigOptionsUtils 81 loadOptionsByClassName - get config option error, class not found: org.apache.flink.configuration.KubernetesConfigOptions
[dinky] 2024-01-03 16:16:52 CST INFO  org.dinky.service.impl.TaskServiceImpl 174 prepareTask - Start check and config task, task:batch-genAndPrint-yarnPerJob
[dinky] 2024-01-03 16:16:52 CST INFO  org.dinky.service.impl.TaskServiceImpl 292 buildEnvSql - Start initialize FlinkSQLEnv:
[dinky] 2024-01-03 16:16:52 CST INFO  org.dinky.service.impl.TaskServiceImpl 312 buildEnvSql - Initializing data permissions...
[dinky] 2024-01-03 16:16:52 CST INFO  org.dinky.service.impl.TaskServiceImpl 314 buildEnvSql - Finish initialize FlinkSQLEnv.
[dinky] 2024-01-03 16:16:52 CST INFO  org.dinky.service.impl.TaskServiceImpl 229 buildJobSubmitConfig - Init gateway config, type:yarn-per-job
[dinky] 2024-01-03 16:16:52 CST INFO  org.dinky.service.impl.TaskServiceImpl 242 buildJobSubmitConfig - Init remote cluster
[dinky] 2024-01-03 16:16:52 CST INFO  org.dinky.service.task.FlinkSqlTask 66 execute - Initializing Flink job config...
[dinky] 2024-01-03 16:16:52 CST INFO  org.dinky.job.builder.JobUDFBuilder 125 run - A total of 0 UDF have been Init.
[dinky] 2024-01-03 16:16:52 CST INFO  org.dinky.job.builder.JobUDFBuilder 126 run - Initializing Flink UDF...Finish
[dinky] 2024-01-03 16:16:52 CST INFO  org.dinky.utils.KerberosUtil 58 authenticate - Simple authentication mode
[dinky] 2024-01-03 16:16:52 CST INFO  org.dinky.utils.KerberosUtil 58 authenticate - Simple authentication mode
[dinky] 2024-01-03 16:16:53 CST ERROR org.dinky.aop.exception.UnKnownExceptionHandler 39 unknownException - java.lang.Exception: Exception in executing FlinkSQL:
1     INSERT INTO
2       PrintSink(
3         order_number,
4         name,
5         price,
6         order_time)
7     SELECT
8       order_number,
9       name,
10      price,
11      order_time
12    FROM
13      DataGenSource

Couldn't deploy Flink Cluster with job graph. org.dinky.data.exception.DinkyException: java.lang.Exception: Exception in executing FlinkSQL:
1     INSERT INTO
2       PrintSink(
3         order_number,
4         name,
5         price,
6         order_time)
7     SELECT
8       order_number,
9       name,
10      price,
11      order_time
12    FROM
13      DataGenSource

Couldn't deploy Flink Cluster with job graph.
	at org.dinky.aop.UdfClassLoaderAspect.round(UdfClassLoaderAspect.java:58) ~[dinky-admin-1.0.0-rc2.jar:?]
	at sun.reflect.GeneratedMethodAccessor234.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_391]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_391]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:634) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:624) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:72) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.dinky.service.impl.TaskServiceImpl$$EnhancerBySpringCGLIB$$3774c39a.submitTask(<generated>) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.dinky.controller.TaskController.submitTask(TaskController.java:80) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.dinky.controller.TaskController$$FastClassBySpringCGLIB$$5b68bd32.invoke(<generated>) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.adapter.AfterReturningAdviceInterceptor.invoke(AfterReturningAdviceInterceptor.java:57) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.AspectJAfterThrowingAdvice.invoke(AspectJAfterThrowingAdvice.java:64) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.adapter.AfterReturningAdviceInterceptor.invoke(AfterReturningAdviceInterceptor.java:57) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint.proceed(MethodInvocationProceedingJoinPoint.java:89) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.dinky.aop.ProcessAspect.processAround(ProcessAspect.java:73) ~[dinky-admin-1.0.0-rc2.jar:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_391]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_391]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_391]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_391]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:634) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:624) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:72) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.dinky.controller.TaskController$$EnhancerBySpringCGLIB$$d81f3042.submitTask(<generated>) ~[dinky-admin-1.0.0-rc2.jar:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_391]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_391]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_391]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_391]
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205) ~[spring-web-5.3.27.jar:5.3.27]
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150) ~[spring-web-5.3.27.jar:5.3.27]
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117) ~[spring-webmvc-5.3.27.jar:5.3.27]
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895) ~[spring-webmvc-5.3.27.jar:5.3.27]
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808) ~[spring-webmvc-5.3.27.jar:5.3.27]
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) ~[spring-webmvc-5.3.27.jar:5.3.27]
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1072) ~[spring-webmvc-5.3.27.jar:5.3.27]
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:965) ~[spring-webmvc-5.3.27.jar:5.3.27]
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006) ~[spring-webmvc-5.3.27.jar:5.3.27]
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898) ~[spring-webmvc-5.3.27.jar:5.3.27]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:529) ~[tomcat-embed-core-9.0.74.jar:4.0.FR]
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883) ~[spring-webmvc-5.3.27.jar:5.3.27]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:623) ~[tomcat-embed-core-9.0.74.jar:4.0.FR]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:209) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51) ~[tomcat-embed-websocket-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.springframework.web.filter.CorsFilter.doFilterInternal(CorsFilter.java:91) ~[spring-web-5.3.27.jar:5.3.27]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.27.jar:5.3.27]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at com.alibaba.druid.support.http.WebStatFilter.doFilter(WebStatFilter.java:124) ~[druid-1.2.8.jar:1.2.8]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100) ~[spring-web-5.3.27.jar:5.3.27]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.27.jar:5.3.27]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at cn.dev33.satoken.filter.SaPathCheckFilterForServlet.doFilter(SaPathCheckFilterForServlet.java:55) ~[sa-token-spring-boot-starter-1.37.0.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93) ~[spring-web-5.3.27.jar:5.3.27]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.27.jar:5.3.27]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.doFilterInternal(WebMvcMetricsFilter.java:96) ~[spring-boot-actuator-2.7.11.jar:2.7.11]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.27.jar:5.3.27]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201) ~[spring-web-5.3.27.jar:5.3.27]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.27.jar:5.3.27]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:178) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:153) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:481) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:130) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:389) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:926) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1791) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-embed-core-9.0.74.jar:9.0.74]
	at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_391]
Caused by: java.lang.Exception: Exception in executing FlinkSQL:
1     INSERT INTO
2       PrintSink(
3         order_number,
4         name,
5         price,
6         order_time)
7     SELECT
8       order_number,
9       name,
10      price,
11      order_time
12    FROM
13      DataGenSource

Couldn't deploy Flink Cluster with job graph.
	at org.dinky.job.JobManager.executeSql(JobManager.java:328) ~[dinky-core-1.0.0-rc2.jar:?]
	at org.dinky.service.task.FlinkSqlTask.execute(FlinkSqlTask.java:67) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.dinky.service.impl.TaskServiceImpl.executeJob(TaskServiceImpl.java:197) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.dinky.service.impl.TaskServiceImpl$$FastClassBySpringCGLIB$$22087f7c.invoke(<generated>) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint.proceed(MethodInvocationProceedingJoinPoint.java:89) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.dinky.aop.ProcessAspect.processStepAround(ProcessAspect.java:110) ~[dinky-admin-1.0.0-rc2.jar:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_391]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_391]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_391]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_391]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:634) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:624) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:72) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.dinky.service.impl.TaskServiceImpl$$EnhancerBySpringCGLIB$$3774c39a.executeJob(<generated>) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.dinky.service.impl.TaskServiceImpl.submitTask(TaskServiceImpl.java:325) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.dinky.service.impl.TaskServiceImpl$$FastClassBySpringCGLIB$$22087f7c.invoke(<generated>) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint.proceed(MethodInvocationProceedingJoinPoint.java:89) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.dinky.aop.UdfClassLoaderAspect.round(UdfClassLoaderAspect.java:55) ~[dinky-admin-1.0.0-rc2.jar:?]
	... 108 more
Caused by: org.dinky.gateway.exception.GatewayException: Couldn't deploy Flink Cluster with job graph.
	at org.dinky.gateway.AbstractGateway.submitJobGraph(AbstractGateway.java:182) ~[dinky-gateway-1.0.0-rc2.jar:?]
	at org.dinky.job.builder.JobTransBuilder.submitByGateway(JobTransBuilder.java:200) ~[dinky-core-1.0.0-rc2.jar:?]
	at org.dinky.job.builder.JobTransBuilder.processWithGateway(JobTransBuilder.java:108) ~[dinky-core-1.0.0-rc2.jar:?]
	at org.dinky.job.builder.JobTransBuilder.handleStatementSet(JobTransBuilder.java:80) ~[dinky-core-1.0.0-rc2.jar:?]
	at org.dinky.job.builder.JobTransBuilder.run(JobTransBuilder.java:69) ~[dinky-core-1.0.0-rc2.jar:?]
	at org.dinky.job.JobManager.executeSql(JobManager.java:310) ~[dinky-core-1.0.0-rc2.jar:?]
	at org.dinky.service.task.FlinkSqlTask.execute(FlinkSqlTask.java:67) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.dinky.service.impl.TaskServiceImpl.executeJob(TaskServiceImpl.java:197) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.dinky.service.impl.TaskServiceImpl$$FastClassBySpringCGLIB$$22087f7c.invoke(<generated>) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint.proceed(MethodInvocationProceedingJoinPoint.java:89) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.dinky.aop.ProcessAspect.processStepAround(ProcessAspect.java:110) ~[dinky-admin-1.0.0-rc2.jar:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_391]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_391]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_391]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_391]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:634) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:624) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:72) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:175) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.dinky.service.impl.TaskServiceImpl$$EnhancerBySpringCGLIB$$3774c39a.executeJob(<generated>) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.dinky.service.impl.TaskServiceImpl.submitTask(TaskServiceImpl.java:325) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.dinky.service.impl.TaskServiceImpl$$FastClassBySpringCGLIB$$22087f7c.invoke(<generated>) ~[dinky-admin-1.0.0-rc2.jar:?]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint.proceed(MethodInvocationProceedingJoinPoint.java:89) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.dinky.aop.UdfClassLoaderAspect.round(UdfClassLoaderAspect.java:55) ~[dinky-admin-1.0.0-rc2.jar:?]
	... 108 more
```
