### PR TITLE
[Optimization] When the cluster instance status is healthy, it needs to be stopped first and then deleted.

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/controller/ClusterInstanceController.java
+++ b/dinky-admin/src/main/java/org/dinky/controller/ClusterInstanceController.java
@@ -204,20 +204,6 @@ public class ClusterInstanceController {
     }
 
     /**
-     * recycle cluster instances
-     *
-     * @return {@link Result}<{@link Integer}>
-     */
-    @DeleteMapping("/recycle")
-    @Log(title = "Cluster Instance Recycle", businessType = BusinessType.DELETE)
-    @ApiOperation("Cluster Instance Recycle")
-    @Transactional(rollbackFor = Exception.class)
-    @SaCheckPermission(value = {PermissionConstants.REGISTRATION_CLUSTER_INSTANCE_RECYCLE})
-    public Result<Integer> recycleCluster() {
-        return Result.succeed(clusterInstanceService.recycleCluster(), Status.CLUSTER_INSTANCE_RECYCLE_SUCCESS);
-    }
-
-    /**
      * kill cluster instance
      *
      * @param id {@link Integer} cluster instance id

--- a/dinky-admin/src/main/java/org/dinky/service/impl/ClusterInstanceServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/ClusterInstanceServiceImpl.java
@@ -171,6 +171,12 @@ public class ClusterInstanceServiceImpl extends SuperServiceImpl<ClusterInstance
         if (hasRelationShip(id)) {
             throw new BusException(Status.CLUSTER_INSTANCE_EXIST_RELATIONSHIP);
         }
+        ClusterInstance clusterInstance = getById(id);
+        // if cluster instance is not null and cluster instance is health, can not delete, must kill cluster instance
+        // first
+        if (Asserts.isNotNull(clusterInstance) && checkHealth(clusterInstance)) {
+            throw new BusException(Status.CLUSTER_INSTANCE_HEALTH_NOT_DELETE);
+        }
         return removeById(id);
     }
 

--- a/dinky-common/src/main/java/org/dinky/data/enums/Status.java
+++ b/dinky-common/src/main/java/org/dinky/data/enums/Status.java
@@ -218,6 +218,7 @@ public enum Status {
     CLUSTER_INSTANCE_EXIST_RELATIONSHIP(15005, "cluster.instance.exist.relationship"),
     CLUSTER_INSTANCE_LOCAL_NOT_SUPPORT_KILL(15006, "cluster.instance.local.not.support.kill"),
     CLUSTER_INSTANCE_NOT_HEALTH(15007, "cluster.instance.not.health"),
+    CLUSTER_INSTANCE_HEALTH_NOT_DELETE(15008, "cluster.instance.health.not.delete"),
 
     /**
      * git

--- a/dinky-common/src/main/resources/i18n/messages_en_US.properties
+++ b/dinky-common/src/main/resources/i18n/messages_en_US.properties
@@ -140,6 +140,7 @@ cluster.not.exist=Cluster Not Exist
 cluster.instance.exist.relationship=Cluster Instance Already Exists Relationship, Can Not Delete
 cluster.instance.local.not.support.kill=Local Mode Cluster Instance Not Support Kill
 cluster.instance.not.health=Cluster Instance Status Not Health
+cluster.instance.health.not.delete=Cluster Instance Status Health, Can Not Delete, Please Stop Cluster Instance First
 cluster.config.exist.relationship=Cluster Config Already Exists Relationship, Can Not Delete
 udf.template.exist.relationship=Udf Template Already Exists Relationship, Can Not Delete
 operate.failed=Operate Failed

--- a/dinky-common/src/main/resources/i18n/messages_zh_CN.properties
+++ b/dinky-common/src/main/resources/i18n/messages_zh_CN.properties
@@ -140,6 +140,7 @@ cluster.not.exist=集群不存在
 cluster.instance.exist.relationship=集群实例已存在关联关系,不允许删除
 cluster.instance.local.not.support.kill=Local 模式集群实例暂未实现停止功能
 cluster.instance.not.health=集群实例状态不健康
+cluster.instance.health.not.delete=集群实例为可用状态,不允许删除,请先停止该集群实例
 cluster.config.exist.relationship=集群配置已存在关联关系,不允许删除
 udf.template.exist.relationship=UDF模板已存在关联关系,不允许删除
 operate.failed=操作失败


### PR DESCRIPTION
…lthy, it needs to be stopped first.

## Purpose of the pull request

- 优化删除 Fink 实例逻辑, 当实例状态是健康时,需要先停止在进行删除

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
