### PR TITLE
[Fix-2947] Fix the issue of missing single quotes in the default value of MySQL table building statements

### DIFF
--- a/dinky-metadata/dinky-metadata-mysql/src/main/java/org/dinky/metadata/driver/MySqlDriver.java
+++ b/dinky-metadata/dinky-metadata-mysql/src/main/java/org/dinky/metadata/driver/MySqlDriver.java
@@ -108,7 +108,7 @@ public class MySqlDriver extends AbstractJdbcDriver {
 
                     final String dv = column.getDefaultValue();
                     String defaultValue = Asserts.isNotNull(dv)
-                            ? String.format(" DEFAULT %s", dv.isEmpty() ? "\"\"" : dv)
+                            ? String.format(" DEFAULT '%s'", dv.isEmpty() ? "''" : dv)
                             : String.format("%s NULL ", !column.isNullable() ? " NOT " : "");
 
                     return String.format(


### PR DESCRIPTION
## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
