### PR TITLE
App fix

### DIFF
--- a/dinky-app/dinky-app-base/src/main/java/org/dinky/app/util/FlinkAppUtil.java
+++ b/dinky-app/dinky-app-base/src/main/java/org/dinky/app/util/FlinkAppUtil.java
@@ -19,22 +19,21 @@
 
 package org.dinky.app.util;
 
-import org.dinky.data.enums.JobStatus;
-import org.dinky.data.model.SystemConfiguration;
-import org.dinky.executor.Executor;
-import org.dinky.utils.JsonUtils;
-
+import cn.hutool.core.text.StrFormatter;
+import cn.hutool.http.HttpUtil;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.client.JobStatusMessage;
+import org.dinky.data.enums.JobStatus;
+import org.dinky.data.model.SystemConfiguration;
+import org.dinky.executor.Executor;
+import org.dinky.utils.JsonUtils;
 
 import java.util.Collection;
-
-import cn.hutool.core.text.StrFormatter;
-import cn.hutool.http.HttpUtil;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Map;
 
 @Slf4j
 public class FlinkAppUtil {
@@ -114,7 +113,8 @@ public class FlinkAppUtil {
     private static RestClusterClient<StandaloneClusterId> createClient(Executor executor) throws Exception {
         ReadableConfig config = executor.getStreamExecutionEnvironment().getConfiguration();
         Configuration configuration = new Configuration((Configuration) config);
-
-        return new RestClusterClient<>(configuration, StandaloneClusterId.getInstance());
+        Map<String, String> map = configuration.toMap();
+        map.remove("web.port");
+        return new RestClusterClient<>(Configuration.fromMap(map), StandaloneClusterId.getInstance());
     }
 }


### PR DESCRIPTION
![image](https://github.com/DataLinkDC/dinky/assets/76773988/b4c424ab-6c22-4e59-af9d-52f1bc5dc837)
使用flink自带的网络工具找到空闲端口绑定port,用于app模式创建RestClusterClient
![image](https://github.com/DataLinkDC/dinky/assets/76773988/edfca30c-80da-4665-a686-5e277dfd542c)
在不适用HA的前提下不绑定port会导致因为默认配置web.port=0无法获取到RestClusterClient
