### PR TITLE
[Optimization][script] Optimizing the classpath in the Dinky startup …

### DIFF
--- a/script/bin/auto.sh
+++ b/script/bin/auto.sh
@@ -4,13 +4,13 @@ FLINK_VERSION=${2:-1.16}
 
 JAR_NAME="dinky-admin"
 
-# Use FLINK_HOME:
-CLASS_PATH=".:./lib/*:config:./extends/*:./plugins/*:./customJar/*:./plugins/flink${FLINK_VERSION}/dinky/*:./plugins/flink${FLINK_VERSION}/*:./extends/flink${FLINK_VERSION}/dinky/*:./extends/flink${FLINK_VERSION}/*"
+APP_HOME="$(cd `dirname $0`; pwd)"
 
+# Use FLINK_HOME:
+CLASS_PATH="${APP_HOME}:${APP_HOME}/lib/*:${APP_HOME}/config:${APP_HOME}/extends/*:${APP_HOME}/plugins/*:${APP_HOME}/customJar/*:${APP_HOME}/plugins/flink${FLINK_VERSION}/dinky/*:${APP_HOME}/plugins/flink${FLINK_VERSION}/*:${APP_HOME}/extends/flink${FLINK_VERSION}/dinky/*:${APP_HOME}/extends/flink${FLINK_VERSION}/*"
 PID_FILE="dinky.pid"
 
 # JMX path
-APP_HOME="$(cd `dirname $0`; pwd)"
 JMX="-javaagent:$APP_HOME/lib/jmx_prometheus_javaagent-0.20.0.jar=10087:$APP_HOME/config/jmx/jmx_exporter_config.yaml"
 
 # Check whether the pid path exists


### PR DESCRIPTION
…script #3076
close #3076
## Purpose of the pull request
related issue
https://github.com/DataLinkDC/dinky/issues/3076

Optimization of the classpath in the Dinky startup script

Due to the use of relative paths in the classpath, launching Dinky can only be done from the Dinky installation directory, which can be inconvenient in some scenarios. The current classpath is:
```
CLASS_PATH=".:./lib/*:config:./extends/*:./plugins/*:./customJar/*:./plugins/flink${FLINK_VERSION}/dinky/*:./plugins/flink${FLINK_VERSION}/*:./extends/flink${FLINK_VERSION}/dinky/*:./extends/flink${FLINK_VERSION}/*"
```
The proposal is to optimize it by using absolute paths based on APP_HOME.


<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

manual test
![image](https://github.com/DataLinkDC/dinky/assets/18082602/38445ec1-e6ed-4872-826d-399986c64891)
![image](https://github.com/DataLinkDC/dinky/assets/18082602/83410331-82fe-4f13-99fc-4c7978385e71)



<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
