### PR TITLE
Override AbstractJdbcDriver method getTable The default method takes …

### DIFF
--- a/dinky-common/src/main/java/org/dinky/data/model/Table.java
+++ b/dinky-common/src/main/java/org/dinky/data/model/Table.java
@@ -19,21 +19,21 @@
 
 package org.dinky.data.model;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.dinky.assertion.Asserts;
 import org.dinky.data.enums.TableType;
 import org.dinky.utils.SqlUtil;
 
 import java.beans.Transient;
 import java.io.Serializable;
+import java.sql.SQLException;
 import java.text.MessageFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import lombok.Getter;
-import lombok.Setter;
 
 /**
  * Table
@@ -56,14 +56,26 @@ public class Table implements Serializable, Comparable<Table>, Cloneable {
     private Long rows;
     private Date createTime;
     private Date updateTime;
-    /** 表类型 */
+    /**
+     * 表类型
+     */
     private TableType tableType = TableType.SINGLE_DATABASE_AND_TABLE;
-    /** 分库或分表对应的表名 */
+    /**
+     * 分库或分表对应的表名
+     */
     private List<String> schemaTableNameList;
 
     private List<Column> columns;
 
-    public Table() {}
+    public Table() {
+    }
+
+    public Table(List<Column> columns, String databaseName, String tableName, String tableComment) throws SQLException {
+        this.name = tableName;
+        this.schema = databaseName;
+        this.comment = tableComment;
+        this.columns = columns;
+    }
 
     public Table(String name, String schema, List<Column> columns) {
         this.name = name;
@@ -144,12 +156,14 @@ public class Table implements Serializable, Comparable<Table>, Cloneable {
         return String.format("DROP TABLE IF EXISTS %s;\n%s", name, createSql);
     }
 
+
     @Override
     public Object clone() {
         Table table = null;
         try {
             table = (Table) super.clone();
-        } catch (CloneNotSupportedException e) {
+        } catch (
+                CloneNotSupportedException e) {
             e.printStackTrace();
         }
         return table;

--- a/dinky-common/src/main/java/org/dinky/data/model/Table.java
+++ b/dinky-common/src/main/java/org/dinky/data/model/Table.java
@@ -19,8 +19,6 @@
 
 package org.dinky.data.model;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.dinky.assertion.Asserts;
 import org.dinky.data.enums.TableType;
 import org.dinky.utils.SqlUtil;
@@ -34,6 +32,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Table
@@ -67,8 +68,7 @@ public class Table implements Serializable, Comparable<Table>, Cloneable {
 
     private List<Column> columns;
 
-    public Table() {
-    }
+    public Table() {}
 
     public Table(List<Column> columns, String databaseName, String tableName, String tableComment) throws SQLException {
         this.name = tableName;
@@ -156,14 +156,12 @@ public class Table implements Serializable, Comparable<Table>, Cloneable {
         return String.format("DROP TABLE IF EXISTS %s;\n%s", name, createSql);
     }
 
-
     @Override
     public Object clone() {
         Table table = null;
         try {
             table = (Table) super.clone();
-        } catch (
-                CloneNotSupportedException e) {
+        } catch (CloneNotSupportedException e) {
             e.printStackTrace();
         }
         return table;

--- a/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/AbstractJdbcDriver.java
+++ b/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/AbstractJdbcDriver.java
@@ -19,12 +19,8 @@
 
 package org.dinky.metadata.driver;
 
-import cn.hutool.core.text.CharSequenceUtil;
-import com.alibaba.druid.pool.DruidDataSource;
-import com.alibaba.druid.pool.DruidPooledConnection;
-import com.alibaba.druid.sql.SQLUtils;
-import com.alibaba.druid.sql.ast.SQLStatement;
-import lombok.extern.slf4j.Slf4j;
+import static org.dinky.utils.SplitUtil.*;
+
 import org.dinky.assertion.Asserts;
 import org.dinky.data.constant.CommonConstant;
 import org.dinky.data.enums.TableType;
@@ -42,15 +38,36 @@ import org.dinky.utils.JsonUtils;
 import org.dinky.utils.LogUtil;
 import org.dinky.utils.TextUtil;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.dinky.utils.SplitUtil.*;
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidPooledConnection;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
 
+import cn.hutool.core.text.CharSequenceUtil;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * AbstractJdbcDriver
@@ -126,9 +143,7 @@ public abstract class AbstractJdbcDriver extends AbstractDriver<AbstractJdbcConf
                 Class.forName(getDriverClass());
                 DruidPooledConnection connection = createDataSource().getConnection();
                 conn.set(connection);
-            } catch (
-                    ClassNotFoundException |
-                    SQLException e) {
+            } catch (ClassNotFoundException | SQLException e) {
                 throw new RuntimeException(e);
             }
         }
@@ -279,7 +294,7 @@ public abstract class AbstractJdbcDriver extends AbstractDriver<AbstractJdbcConf
     public Table getTable(String schemaName, String tableName) {
         try {
             DatabaseMetaData metaData = conn.get().getMetaData();
-            ResultSet tables = metaData.getTables(schemaName, null, tableName, new String[]{"TABLE"});
+            ResultSet tables = metaData.getTables(schemaName, null, tableName, new String[] {"TABLE"});
             while (tables.next()) {
                 String tableComment = tables.getString("REMARKS");
                 List<Column> columns = listColumns(schemaName, tableName);
@@ -824,8 +839,7 @@ public abstract class AbstractJdbcDriver extends AbstractDriver<AbstractJdbcConf
                                 tableInfo.setUpdateTime(
                                         SimpleDateFormat.getDateInstance().parse(updateTime));
                             }
-                        } catch (
-                                ParseException ignored) {
+                        } catch (ParseException ignored) {
                             log.warn("set date fail");
                         }
                         TableType tableType = TableType.type(
@@ -839,8 +853,8 @@ public abstract class AbstractJdbcDriver extends AbstractDriver<AbstractJdbcConf
                                     + getReValue(x.get(dbQuery.tableName()), splitConfig);
                             List<String> schemaTableNameList = mapList.stream()
                                     .filter(y -> (getReValue(y.get(dbQuery.schemaName()), splitConfig)
-                                            + "."
-                                            + getReValue(y.get(dbQuery.tableName()), splitConfig))
+                                                    + "."
+                                                    + getReValue(y.get(dbQuery.tableName()), splitConfig))
                                             .equals(currentSchemaName))
                                     .map(y -> y.get(dbQuery.schemaName()) + "." + y.get(dbQuery.tableName()))
                                     .collect(Collectors.toList());

--- a/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/AbstractJdbcDriver.java
+++ b/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/AbstractJdbcDriver.java
@@ -51,6 +51,7 @@ import java.util.stream.Stream;
 
 import static org.dinky.utils.SplitUtil.*;
 
+
 /**
  * AbstractJdbcDriver
  *
@@ -60,9 +61,8 @@ import static org.dinky.utils.SplitUtil.*;
 public abstract class AbstractJdbcDriver extends AbstractDriver<AbstractJdbcConfig> {
 
     protected ThreadLocal<Connection> conn = new ThreadLocal<>();
-
-    private DruidDataSource dataSource;
     protected String validationQuery = "select 1";
+    private DruidDataSource dataSource;
 
     abstract String getDriverClass();
 

--- a/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/AbstractJdbcDriver.java
+++ b/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/AbstractJdbcDriver.java
@@ -286,6 +286,7 @@ public abstract class AbstractJdbcDriver extends AbstractDriver<AbstractJdbcConf
                 return new Table(columns, schemaName, tableName, tableComment);
             }
         } catch (SQLException e) {
+            log.error("GetTable error:", e);
             throw new RuntimeException(e);
         }
         return null;

--- a/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/AbstractJdbcDriver.java
+++ b/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/AbstractJdbcDriver.java
@@ -19,7 +19,9 @@
 
 package org.dinky.metadata.driver;
 
-import static org.dinky.utils.SplitUtil.*;
+import static org.dinky.utils.SplitUtil.contains;
+import static org.dinky.utils.SplitUtil.getReValue;
+import static org.dinky.utils.SplitUtil.isSplit;
 
 import org.dinky.assertion.Asserts;
 import org.dinky.data.constant.CommonConstant;


### PR DESCRIPTION

![image](https://github.com/DataLinkDC/dinky/assets/76773988/fbe22904-18ff-4760-a2b2-5985def15e5d)

![image](https://github.com/DataLinkDC/dinky/assets/76773988/3601bf4c-5879-41ee-af67-2e69c06b8122)
原方法需要获取数据库中全部表的元数据再过滤比较花费时间