### PR TITLE
[Fix-3196] [datastudio] Data too long for column 'job_id'(varchar(50)) in table dinky_history

### DIFF
--- a/script/sql/dinky-mysql.sql
+++ b/script/sql/dinky-mysql.sql
@@ -1174,7 +1174,7 @@ CREATE TABLE `dinky_history`  (
                                 `cluster_id` int(11) NOT NULL DEFAULT 0 COMMENT 'cluster ID',
                                 `cluster_configuration_id` int(11) NULL DEFAULT NULL COMMENT 'cluster configuration id',
                                 `session` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL COMMENT 'session',
-                                `job_id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL COMMENT 'Job ID',
+                                `job_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL COMMENT 'Job ID',
                                 `job_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL COMMENT 'Job Name',
                                 `job_manager_address` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL COMMENT 'JJobManager Address',
                                 `status` int(11) NOT NULL DEFAULT 0 COMMENT 'status',

--- a/script/sql/dinky-pg.sql
+++ b/script/sql/dinky-pg.sql
@@ -2365,7 +2365,7 @@ CREATE TABLE dinky_history
     cluster_id               INT                NOT NULL DEFAULT 0,
     cluster_configuration_id INT                NULL,
     session                  VARCHAR(255)       NULL,
-    job_id                   VARCHAR(50)        NULL,
+    job_id                   VARCHAR(255)        NULL,
     job_name                 VARCHAR(255)       NULL,
     job_manager_address      VARCHAR(255)       NULL,
     status                   INT                NOT NULL DEFAULT 0,

--- a/script/sql/upgrade/1.0.0_schema/mysql/dinky_ddl.sql
+++ b/script/sql/upgrade/1.0.0_schema/mysql/dinky_ddl.sql
@@ -443,5 +443,9 @@ alter table dinky_database
 alter table dinky_database
     drop column password;
 
+alter table dinky_history
+    modify job_id varchar(255) null comment 'Job ID';
+
+
 
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION

## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
