### PR TITLE
[Optimization][admin] NULL may be used when optimizing heartbeat detection of cluster instances

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/assertion/DinkyAssert.java
+++ b/dinky-admin/src/main/java/org/dinky/assertion/DinkyAssert.java
@@ -33,6 +33,9 @@ import org.dinky.data.model.Task;
 public interface DinkyAssert {
 
     static void check(ClusterInstance clusterInstance) {
+        if (clusterInstance == null) {
+            throw new BusException("Flink集群不存在");
+        }
         if (clusterInstance.getId() == null) {
             throw new BusException("Flink 集群【" + clusterInstance.getId() + "】不存在");
         }

--- a/dinky-admin/src/main/java/org/dinky/assertion/DinkyAssert.java
+++ b/dinky-admin/src/main/java/org/dinky/assertion/DinkyAssert.java
@@ -34,7 +34,7 @@ public interface DinkyAssert {
 
     static void check(ClusterInstance clusterInstance) {
         if (clusterInstance == null) {
-            throw new BusException("Flink集群不存在");
+            throw new BusException(Status.CLUSTER_NOT_EXIST);
         }
         if (clusterInstance.getId() == null) {
             throw new BusException("Flink 集群【" + clusterInstance.getId() + "】不存在");


### PR DESCRIPTION

## Purpose of the pull request

close #3274 

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log
en: NULL may be used when optimizing heartbeat detection of cluster instances
cn: 优化集群实例心跳检测时可能为空的问题
<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
