### PR TITLE
[Fix][docker] Fix the  docker file of DockerfileDinkyFlink

### DIFF
--- a/docker/DockerfileDinkyFlink
+++ b/docker/DockerfileDinkyFlink
@@ -13,9 +13,9 @@ ARG FLINK_BIG_VERSION
 ENV FLINK_BIG_VERSION=${FLINK_BIG_VERSION}
 
 COPY --from=build-stage /opt/dinky/ /opt/dinky/
-COPY --from=reqired-stage  /opt/flink/lib/*.jar  /opt/dinky/plugins/flink${FLINK_BIG_VERSION}/
-RUN rm -f  /opt/dinky/plugins/flink${FLINK_BIG_VERSION}/flink-table-planner-loader*.jar
-COPY --from=reqired-stage  /opt/flink/opt/flink-table-planner*.jar  /opt/dinky/plugins/flink${FLINK_BIG_VERSION}/
+COPY --from=reqired-stage  /opt/flink/lib/*.jar  /opt/dinky/extends/flink${FLINK_BIG_VERSION}/
+RUN rm -f  /opt/dinky/extends/flink${FLINK_BIG_VERSION}/flink-table-planner-loader*.jar
+COPY --from=reqired-stage  /opt/flink/opt/flink-table-planner*.jar  /opt/dinky/extends/flink${FLINK_BIG_VERSION}/
 
 WORKDIR /opt/dinky/
 


### PR DESCRIPTION

## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->
Fix the  docker file of DockerfileDinkyFlink. The jar path of flink must be the same as that in the auto.sh

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
