### PR TITLE
[Optimization] [SQL] Increase dinky_udf_manage table's class_name column's length from 50 to 100

### DIFF
--- a/script/sql/dinky-mysql.sql
+++ b/script/sql/dinky-mysql.sql
@@ -2012,7 +2012,7 @@ drop table if exists `dinky_udf_manage`;
 CREATE TABLE `dinky_udf_manage` (
                                     `id` int(11) NOT NULL AUTO_INCREMENT,
                                     `name` varchar(50) DEFAULT NULL COMMENT 'udf name',
-                                    `class_name` varchar(50) DEFAULT NULL COMMENT 'Complete class name',
+                                    `class_name` varchar(100) DEFAULT NULL COMMENT 'Complete class name',
                                     `task_id` int(11) DEFAULT NULL COMMENT 'task id',
                                     `resources_id` int(11) DEFAULT NULL COMMENT 'resources id',
                                     `enabled` tinyint(1) DEFAULT 1 COMMENT 'is enable',

--- a/script/sql/dinky-pg.sql
+++ b/script/sql/dinky-pg.sql
@@ -4059,7 +4059,7 @@ CREATE TABLE dinky_udf_manage
 (
     id           SERIAL PRIMARY KEY          NOT NULL,
     name         VARCHAR(50),
-    class_name   VARCHAR(50),
+    class_name   VARCHAR(100),
     task_id      INT,
     resources_id INT,
     enabled      BOOLEAN                              DEFAULT TRUE,

--- a/script/sql/upgrade/1.1.0_schema/mysql/dinky_ddl.sql
+++ b/script/sql/upgrade/1.1.0_schema/mysql/dinky_ddl.sql
@@ -1,0 +1,26 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- Increase class_name column's length from 50 to 100.
+ALTER TABLE dinky_udf_manage CHANGE COLUMN class_name class_name VARCHAR(100) null DEFAULT null COMMENT 'Complete class name';
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/script/sql/upgrade/1.1.0_schema/postgre/dinky_ddl.sql
+++ b/script/sql/upgrade/1.1.0_schema/postgre/dinky_ddl.sql
@@ -1,0 +1,23 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+-- Increase class_name column's length from 50 to 100.
+ALTER TABLE dinky_udf_manage ALTER COLUMN class_name TYPE VARCHAR(100);
+
+COMMENT ON COLUMN dinky_udf_manage.class_name IS 'Complete class name';


### PR DESCRIPTION
## Purpose of the pull request

SQL optimization to increase dinky_udf_manage table's class_name column's length from 50 to 100.

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
