### PR TITLE
Feat: Adapt to multiple rest svcTypes in KubernetsApplicationOperator mode and modify the JobId acquisition judgment logic

### DIFF
--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubetnetsApplicationOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubetnetsApplicationOperatorGateway.java
@@ -21,6 +21,7 @@ package org.dinky.gateway.kubernetes.operator;
 
 import org.dinky.assertion.Asserts;
 import org.dinky.context.FlinkUdfPathContextHolder;
+import org.dinky.data.constant.NetConstant;
 import org.dinky.data.enums.GatewayType;
 import org.dinky.gateway.kubernetes.operator.api.FlinkDeployment;
 import org.dinky.gateway.result.GatewayResult;
@@ -28,13 +29,16 @@ import org.dinky.gateway.result.KubernetesResult;
 import org.dinky.utils.LogUtil;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import cn.hutool.http.HttpUtil;
 import io.fabric8.kubernetes.api.model.ListOptions;
+import io.fabric8.kubernetes.api.model.NodeAddress;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.api.model.ServicePort;
@@ -49,6 +53,10 @@ public class KubetnetsApplicationOperatorGateway extends KubernetsOperatorGatewa
     public GatewayType getType() {
         return GatewayType.KUBERNETES_APPLICATION_OPERATOR;
     }
+
+    private static final String CLUSTER_IP = "ClusterIP";
+    private static final String NODE_PORT = "NodePort";
+    private static final String LOAD_BALANCER = "LoadBalancer";
 
     @Override
     public GatewayResult submitJar(FlinkUdfPathContextHolder udfPathContextHolder) {
@@ -66,13 +74,13 @@ public class KubetnetsApplicationOperatorGateway extends KubernetsOperatorGatewa
             kubernetesClient.resource(flinkDeployment).delete();
             kubernetesClient.resource(flinkDeployment).waitUntilCondition(Objects::isNull, 1, TimeUnit.MINUTES);
             kubernetesClient.resource(flinkDeployment).createOrReplace();
-            logger.info("create flink deployment finish,wait for flink jobmanager ready");
 
             FlinkDeployment flinkDeploymentResult = kubernetesClient
                     .resource(flinkDeployment)
                     .waitUntilCondition(
                             flinkDeployment1 -> {
                                 if (Asserts.isNull(flinkDeployment1.getStatus())) {
+
                                     return false;
                                 }
                                 String status = String.valueOf(
@@ -85,12 +93,20 @@ public class KubetnetsApplicationOperatorGateway extends KubernetsOperatorGatewa
                                     throw new RuntimeException(error);
                                 }
                                 if (status.equals("READY")) {
-                                    logger.info("deploy kubernetes success ");
                                     String jobId = flinkDeployment1
                                             .getStatus()
                                             .getJobStatus()
                                             .getJobId();
+                                    String jobName = flinkDeployment1
+                                            .getStatus()
+                                            .getJobStatus()
+                                            .getJobName();
+                                    if (Asserts.isNull(jobName)) {
+                                        logger.warn("waiting for job init");
+                                        return false;
+                                    }
                                     result.setJids(Collections.singletonList(jobId));
+                                    logger.info("deploy kubernetes success ");
                                     return true;
                                 }
                                 if (status.equals("DEPLOYING")) {
@@ -113,26 +129,97 @@ public class KubetnetsApplicationOperatorGateway extends KubernetsOperatorGatewa
             String serviceName = config.getFlinkConfig().getJobName() + "-rest";
             options.setFieldSelector("metadata.name=" + serviceName);
             ServiceList list = kubernetesClient.services().list(options);
-            StringBuilder ipPort = new StringBuilder();
-            for (Service item : list.getItems()) {
-                ipPort.append(item.getSpec().getClusterIP());
-                for (ServicePort servicePort : item.getSpec().getPorts()) {
-                    if (servicePort.getName().equals("rest")) {
-                        ipPort.append(":").append(servicePort.getPort());
-                    }
-                }
-            }
-
+            String ipPort = getWebUrl(list, kubernetesClient);
             result.setWebURL("http://" + ipPort);
             result.setId(result.getJids().get(0) + System.currentTimeMillis());
             result.success();
         } catch (KubernetesClientException e) {
             // some error while connecting to kube cluster
             result.fail(LogUtil.getError(e));
-            throw e;
+            e.printStackTrace();
         }
         logger.info(
-                "submit {} job finish, web url is {}, jobid is {}", getType(), result.getWebURL(), result.getJids());
+                "submit {} job finish, web url is {} , jobid is {}", getType(), result.getWebURL(), result.getJids());
         return result;
+    }
+
+    /**
+     * 根据实际环境 获取web url
+     *
+     * @param list
+     * @return
+     */
+    public String getWebUrl(ServiceList list, KubernetesClient kubernetesClient) {
+        StringBuilder ipPort = new StringBuilder();
+        StringBuilder svcRestPort = new StringBuilder();
+        StringBuilder svcType = new StringBuilder();
+        for (Service item : list.getItems()) {
+            svcRestPort
+                    .append(item.getMetadata().getName())
+                    .append(".")
+                    .append(item.getMetadata().getNamespace());
+            svcType.append(item.getSpec().getType());
+            for (ServicePort servicePort : item.getSpec().getPorts()) {
+                if (servicePort.getName().equals("rest")) {
+                    switch (svcType.toString()) {
+                        case CLUSTER_IP:
+                            ipPort.append(item.getSpec().getClusterIP());
+                            ipPort.append(":")
+                                    .append(item.getSpec().getPorts().get(0).getPort());
+                            break;
+                        case NODE_PORT:
+                            List<NodeAddress> addresses = kubernetesClient
+                                    .nodes()
+                                    .list()
+                                    .getItems()
+                                    .get(0)
+                                    .getStatus()
+                                    .getAddresses();
+                            for (NodeAddress address : addresses) {
+                                if (address.getType().equals("InternalIP")) {
+                                    ipPort.append(address.getAddress());
+                                    break;
+                                }
+                            }
+                            ipPort.append(":")
+                                    .append(item.getSpec().getPorts().get(0).getNodePort());
+                            break;
+                            // TODO 没有环境测试不了
+                        case LOAD_BALANCER:
+                            ipPort.append(":")
+                                    .append(item.getSpec().getPorts().get(0).getPort());
+                            svcRestPort
+                                    .append(":")
+                                    .append(item.getSpec().getPorts().get(0).getPort());
+                            break;
+                        default:
+                            break;
+                    }
+                    svcRestPort
+                            .append(":")
+                            .append(item.getSpec().getPorts().get(0).getPort());
+                }
+            }
+        }
+        logger.info("get ipPort {} , svcRestPort {}", ipPort.toString(), svcRestPort.toString());
+        if (pingIpPort(ipPort.toString())) {
+            return ipPort.toString();
+        } else if (pingIpPort(svcRestPort.toString())) {
+            return svcRestPort.toString();
+        } else {
+            throw new RuntimeException("all ip port is not available ");
+        }
+    }
+
+    private boolean pingIpPort(String ipPort) {
+        logger.info("ping ip port {}", ipPort);
+        try {
+            String url = NetConstant.HTTP + ipPort + NetConstant.SLASH + "config";
+            HttpUtil.get(url, NetConstant.SERVER_TIME_OUT_ACTIVE);
+        } catch (Exception e) {
+            logger.warn("ping ip port error", e);
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
…解决在Master还在init Graph情况下Operator返回错误JobId的现象。

## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
