### PR TITLE
[Feature] support kyuubi as a datasource

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/controller/DataSourceController.java
+++ b/dinky-admin/src/main/java/org/dinky/controller/DataSourceController.java
@@ -237,7 +237,6 @@ public class DataSourceController {
      * @param id {@link Integer}
      * @return {@link Result}< {@link List}< {@link Schema}>>
      */
-    @Cacheable(cacheNames = "metadata_schema", key = "#id")
     @GetMapping("/getSchemasAndTables")
     @ApiOperation("Get All Schemas And Tables")
     @ApiImplicitParam(

--- a/dinky-admin/src/main/java/org/dinky/service/task/CommonSqlTask.java
+++ b/dinky-admin/src/main/java/org/dinky/service/task/CommonSqlTask.java
@@ -44,7 +44,8 @@ import lombok.extern.slf4j.Slf4j;
     Dialect.DORIS,
     Dialect.PHOENIX,
     Dialect.STAR_ROCKS,
-    Dialect.PRESTO
+    Dialect.PRESTO,
+    Dialect.KYUUBI
 })
 public class CommonSqlTask extends BaseTask {
 

--- a/dinky-admin/src/main/java/org/dinky/utils/PaimonUtil.java
+++ b/dinky-admin/src/main/java/org/dinky/utils/PaimonUtil.java
@@ -135,6 +135,9 @@ public class PaimonUtil {
                     DataType type = dataField.type();
                     String fieldName = StrUtil.toCamelCase(dataField.name());
                     Object fieldValue = ReflectUtil.getFieldValue(t, fieldName);
+                    if (fieldValue == null){
+                        continue;
+                    }
                     try {
                         // TODO BinaryWriter.write已被废弃，后续可以考虑改成这种方式
                         // BinaryWriter.createValueSetter(type).setValue(writer, i, fieldValue);

--- a/dinky-assembly/src/main/assembly/package.xml
+++ b/dinky-assembly/src/main/assembly/package.xml
@@ -211,6 +211,14 @@
             </includes>
         </fileSet>
         <fileSet>
+            <directory>${project.parent.basedir}/dinky-metadata/dinky-metadata-kyuubi/target
+            </directory>
+            <outputDirectory>lib</outputDirectory>
+            <includes>
+                <include>dinky-metadata-kyuubi-${project.version}.jar</include>
+            </includes>
+        </fileSet>
+        <fileSet>
             <directory>${project.parent.basedir}/dinky-alert/dinky-alert-dingtalk/target
             </directory>
             <outputDirectory>lib</outputDirectory>

--- a/dinky-common/src/main/java/org/dinky/config/Dialect.java
+++ b/dinky-common/src/main/java/org/dinky/config/Dialect.java
@@ -44,6 +44,7 @@ public enum Dialect {
     HIVE("Hive"),
     STAR_ROCKS("StarRocks"),
     PRESTO("Presto"),
+    KYUUBI("Kyuubi"),
     KUBERNETES_APPLICATION("KubernetesApplication");
 
     private String value;

--- a/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/enums/DriverType.java
+++ b/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/enums/DriverType.java
@@ -40,7 +40,10 @@ public enum DriverType {
     PHOENIX("Phoenix"),
     GREENPLUM("Greenplum"),
     HIVE("Hive"),
+    KYUUBI("Kyuubi"),
     PRESTO("Presto");
+
+
 
     public final String value;
 

--- a/dinky-metadata/dinky-metadata-kyuubi/pom.xml
+++ b/dinky-metadata/dinky-metadata-kyuubi/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.dinky</groupId>
+        <artifactId>dinky-metadata</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>dinky-metadata-kyuubi</artifactId>
+
+    <packaging>jar</packaging>
+
+    <name>Dinky : Metadata : Kyuubi</name>
+
+    <properties>
+        <hive.version>2.3.9</hive.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.dinky</groupId>
+            <artifactId>dinky-metadata-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>druid-spring-boot-starter</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <version>1.6.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-jdbc</artifactId>
+            <version>${hive.version}</version>
+            <!--  If you use cdh hive comment out the previous line to open the next line and open the repositories below-->
+            <!--            <version>2.1.1-cdh6.3.2</version>-->
+            <scope>${scope.runtime}</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-service</artifactId>
+            <version>${hive.version}</version>
+            <!--  If you use cdh hive comment out the previous line to open the next line and open the repositories below  -->
+            <!--            <version>2.1.1-cdh6.3.2</version>-->
+            <scope>${scope.runtime}</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-exec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+    </dependencies>
+
+    <!--    <repositories>-->
+    <!--        <repository>-->
+    <!--            <id>cloudera</id>-->
+    <!--            <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>-->
+    <!--        </repository>-->
+    <!--    </repositories>-->
+
+</project>

--- a/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/constant/KyuubiConstant.java
+++ b/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/constant/KyuubiConstant.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.metadata.constant;
+
+public interface KyuubiConstant {
+
+    /** 查询所有database */
+    String QUERY_ALL_DATABASE = " show databases";
+    /** 查询所有schema下的所有表 */
+    String QUERY_ALL_TABLES_BY_SCHEMA = "show tables";
+    /** 扩展信息Key */
+    String DETAILED_TABLE_INFO = "Detailed Table Information";
+    /** 查询指定schema.table的扩展信息 */
+    String QUERY_TABLE_SCHEMA_EXTENED_INFOS = " describe extended `%s`.`%s`";
+    /** 查询指定schema.table的信息 列 列类型 列注释 */
+    String QUERY_TABLE_SCHEMA = " describe `%s`.`%s`";
+    /** 使用 DB */
+    String USE_DB = "use `%s`";
+    /** 只查询指定schema.table的列名 */
+    String QUERY_TABLE_COLUMNS_ONLY = "show columns in `%s`.`%s`";
+}

--- a/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/constant/TrinoEngineConstant.java
+++ b/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/constant/TrinoEngineConstant.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.metadata.constant;
+
+public interface TrinoEngineConstant {
+
+    /** 查询所有database */
+    String QUERY_ALL_DATABASE = "show catalogs";
+    /** 查询某个schema下的所有表 */
+    String QUERY_ALL_TABLES_BY_SCHEMA = "show tables from %s";
+    /** 查询指定schema.table的信息 列 列类型 列注释 */
+    String QUERY_TABLE_SCHEMA = " describe %s.%s";
+    /** 只查询指定schema.table的列名 */
+    String QUERY_TABLE_COLUMNS_ONLY = "show schemas from %s";
+    /** 查询schema列名 */
+    String SCHEMA = "SCHEMA";
+    /** 需要排除的catalog */
+    String EXTRA_SCHEMA = "system";
+    /** 需要排除的schema */
+    String EXTRA_DB = "information_schema";
+}

--- a/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/convert/KyuubiTypeConvert.java
+++ b/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/convert/KyuubiTypeConvert.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.metadata.convert;
+
+import org.dinky.data.enums.ColumnType;
+
+public class KyuubiTypeConvert extends AbstractJdbcTypeConvert {
+
+    public KyuubiTypeConvert() {
+        this.convertMap.clear();
+        register("char", ColumnType.STRING);
+        register("boolean", ColumnType.BOOLEAN, ColumnType.JAVA_LANG_BOOLEAN);
+        register("tinyint", ColumnType.BYTE, ColumnType.JAVA_LANG_BYTE);
+        register("smallint", ColumnType.SHORT, ColumnType.JAVA_LANG_SHORT);
+        register("bigint", ColumnType.LONG, ColumnType.JAVA_LANG_LONG);
+        register("largeint", ColumnType.STRING);
+        register("int", ColumnType.INT, ColumnType.INTEGER);
+        register("float", ColumnType.FLOAT, ColumnType.JAVA_LANG_FLOAT);
+        register("double", ColumnType.DOUBLE, ColumnType.JAVA_LANG_DOUBLE);
+        register("timestamp", ColumnType.TIMESTAMP);
+        register("date", ColumnType.STRING);
+        register("datetime", ColumnType.STRING);
+        register("decimal", ColumnType.DECIMAL);
+        register("time", ColumnType.DOUBLE, ColumnType.JAVA_LANG_DOUBLE);
+    }
+
+    @Override
+    public String convertToDB(ColumnType columnType) {
+        switch (columnType) {
+            case STRING:
+                return "varchar";
+            case BOOLEAN:
+            case JAVA_LANG_BOOLEAN:
+                return "boolean";
+            case BYTE:
+            case JAVA_LANG_BYTE:
+                return "tinyint";
+            case SHORT:
+            case JAVA_LANG_SHORT:
+                return "smallint";
+            case LONG:
+            case JAVA_LANG_LONG:
+                return "bigint";
+            case FLOAT:
+            case JAVA_LANG_FLOAT:
+                return "float";
+            case DOUBLE:
+            case JAVA_LANG_DOUBLE:
+                return "double";
+            case DECIMAL:
+                return "decimal";
+            case INT:
+            case INTEGER:
+                return "int";
+            case TIMESTAMP:
+                return "timestamp";
+            default:
+                return "varchar";
+        }
+    }
+}

--- a/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/query/FlinkEngineQuery.java
+++ b/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/query/FlinkEngineQuery.java
@@ -1,0 +1,20 @@
+package org.dinky.metadata.query;
+
+import org.dinky.metadata.constant.KyuubiConstant;
+
+public class FlinkEngineQuery extends KyuubiEngineQuery{
+    @Override
+    public String schemaAllSql() {
+        return KyuubiConstant.QUERY_ALL_DATABASE;
+    }
+
+    @Override
+    public String tablesSql(String schemaName) {
+        return KyuubiConstant.QUERY_ALL_TABLES_BY_SCHEMA;
+    }
+
+    @Override
+    public String columnsSql(String schemaName, String tableName) {
+        return String.format(KyuubiConstant.QUERY_TABLE_SCHEMA, schemaName, tableName);
+    }
+}

--- a/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/query/HiveEngineQuery.java
+++ b/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/query/HiveEngineQuery.java
@@ -1,0 +1,56 @@
+package org.dinky.metadata.query;
+
+import org.dinky.metadata.constant.KyuubiConstant;
+
+public class HiveEngineQuery extends KyuubiEngineQuery{
+
+    @Override
+    public String schemaAllSql() {
+        return KyuubiConstant.QUERY_ALL_DATABASE;
+    }
+
+    @Override
+    public String tablesSql(String schemaName) {
+        return KyuubiConstant.QUERY_ALL_TABLES_BY_SCHEMA;
+    }
+
+    @Override
+    public String columnsSql(String schemaName, String tableName) {
+        return String.format(KyuubiConstant.QUERY_TABLE_SCHEMA, schemaName, tableName);
+    }
+
+    @Override
+    public String schemaName() {
+        return "database_name";
+    }
+
+    @Override
+    public String createTableName() {
+        return "createtab_stmt";
+    }
+
+    @Override
+    public String tableName() {
+        return "tab_name";
+    }
+
+    @Override
+    public String tableComment() {
+        return "comment";
+    }
+
+    @Override
+    public String columnName() {
+        return "col_name";
+    }
+
+    @Override
+    public String columnType() {
+        return "data_type";
+    }
+
+    @Override
+    public String columnComment() {
+        return "comment";
+    }
+}

--- a/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/query/KyuubiEngineQuery.java
+++ b/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/query/KyuubiEngineQuery.java
@@ -1,0 +1,5 @@
+package org.dinky.metadata.query;
+
+public abstract class KyuubiEngineQuery extends AbstractDBQuery{
+
+}

--- a/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/query/KyuubiQueryFactory.java
+++ b/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/query/KyuubiQueryFactory.java
@@ -1,0 +1,18 @@
+package org.dinky.metadata.query;
+
+public class KyuubiQueryFactory {
+    public static IDBQuery getKyuubiQuery(String databaseType) {
+        switch (databaseType) {
+            case "Spark":
+                return new SparkEngineQuery();
+            case "Hive":
+                return new HiveEngineQuery();
+            case "Trino":
+                return new TrinoEngineQuery();
+            case "Flink":
+                return new FlinkEngineQuery();
+            default:
+                throw new IllegalArgumentException("Unsupported database type: " + databaseType);
+        }
+    }
+}

--- a/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/query/SparkEngineQuery.java
+++ b/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/query/SparkEngineQuery.java
@@ -1,0 +1,56 @@
+package org.dinky.metadata.query;
+
+import org.dinky.metadata.constant.KyuubiConstant;
+
+public class SparkEngineQuery extends KyuubiEngineQuery{
+
+        @Override
+        public String schemaAllSql() {
+            return KyuubiConstant.QUERY_ALL_DATABASE;
+        }
+
+        @Override
+        public String tablesSql(String schemaName) {
+            return KyuubiConstant.QUERY_ALL_TABLES_BY_SCHEMA;
+        }
+
+        @Override
+        public String columnsSql(String schemaName, String tableName) {
+            return String.format(KyuubiConstant.QUERY_TABLE_SCHEMA, schemaName, tableName);
+        }
+
+        @Override
+        public String schemaName() {
+            return "namespace";
+        }
+
+        @Override
+        public String createTableName() {
+            return "createtab_stmt";
+        }
+
+        @Override
+        public String tableName() {
+            return "tab_name";
+        }
+
+        @Override
+        public String tableComment() {
+            return "comment";
+        }
+
+        @Override
+        public String columnName() {
+            return "col_name";
+        }
+
+        @Override
+        public String columnType() {
+            return "data_type";
+        }
+
+        @Override
+        public String columnComment() {
+            return "comment";
+        }
+}

--- a/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/query/TrinoEngineQuery.java
+++ b/dinky-metadata/dinky-metadata-kyuubi/src/main/java/org/dinky/metadata/query/TrinoEngineQuery.java
@@ -1,0 +1,55 @@
+package org.dinky.metadata.query;
+import org.dinky.metadata.constant.TrinoEngineConstant;
+
+public class TrinoEngineQuery extends KyuubiEngineQuery {
+
+    @Override
+    public String schemaAllSql() {
+        return TrinoEngineConstant.QUERY_ALL_DATABASE;
+    }
+
+    @Override
+    public String tablesSql(String schemaName) {
+        return TrinoEngineConstant.QUERY_ALL_TABLES_BY_SCHEMA;
+    }
+
+    @Override
+    public String columnsSql(String schemaName, String tableName) {
+        return String.format(TrinoEngineConstant.QUERY_TABLE_SCHEMA, schemaName, tableName);
+    }
+
+    @Override
+    public String schemaName() {
+        return "Catalog";
+    }
+
+    @Override
+    public String createTableName() {
+        return "Create Table";
+    }
+
+    @Override
+    public String tableName() {
+        return "Table";
+    }
+
+    @Override
+    public String tableComment() {
+        return "Comment";
+    }
+
+    @Override
+    public String columnName() {
+        return "Column";
+    }
+
+    @Override
+    public String columnType() {
+        return "Type";
+    }
+
+    @Override
+    public String columnComment() {
+        return "Comment";
+    }
+}

--- a/dinky-metadata/dinky-metadata-kyuubi/src/main/resources/META-INF/services/org.dinky.metadata.driver.Driver
+++ b/dinky-metadata/dinky-metadata-kyuubi/src/main/resources/META-INF/services/org.dinky.metadata.driver.Driver
@@ -1,0 +1,1 @@
+org.dinky.metadata.driver.KyuubiDriver

--- a/dinky-metadata/dinky-metadata-kyuubi/src/test/java/org/dinky/metadata/HiveTest.java
+++ b/dinky-metadata/dinky-metadata-kyuubi/src/test/java/org/dinky/metadata/HiveTest.java
@@ -1,0 +1,171 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.metadata;
+
+import org.dinky.data.model.Column;
+import org.dinky.data.model.Schema;
+import org.dinky.data.model.Table;
+import org.dinky.metadata.config.AbstractJdbcConfig;
+import org.dinky.metadata.config.DriverConfig;
+import org.dinky.metadata.driver.Driver;
+import org.dinky.metadata.result.JdbcSelectResult;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * MysqlTest
+ *
+ * @since 2021/7/20 15:32
+ */
+@Ignore
+public class HiveTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HiveTest.class);
+
+    private static final String IP = "cdh1";
+    private static final Integer PORT = 10000;
+    private static final String hiveDB = "test";
+    private static final String username = "zhumingye";
+    private static final String passwd = "123456";
+    private static final String hive = "Hive";
+
+    private static String url = "jdbc:hive2://" + IP + ":" + PORT + "/" + hiveDB;
+
+    public Driver getDriver() {
+        DriverConfig<AbstractJdbcConfig> config = new DriverConfig<>();
+        config.setType(hive);
+        config.setName(hive);
+        config.setConnectConfig(AbstractJdbcConfig.builder()
+                .ip(IP)
+                .port(PORT)
+                .username(username)
+                .password(passwd)
+                .url(url)
+                .build());
+        return Driver.build(config);
+    }
+
+    @Ignore
+    @Test
+    public void connectTest() {
+        DriverConfig<AbstractJdbcConfig> config = new DriverConfig<>();
+        config.setType(hive);
+        config.setName(hive);
+        config.setConnectConfig(AbstractJdbcConfig.builder()
+                .ip(IP)
+                .port(PORT)
+                .username(username)
+                .password(passwd)
+                .url(url)
+                .build());
+        String test = Driver.build(config).test();
+        LOGGER.info(test);
+        LOGGER.info("end...");
+    }
+
+    @Ignore
+    @Test
+    public void getDBSTest() {
+        Driver driver = getDriver();
+        List<Schema> schemasAndTables = driver.listSchemas();
+        schemasAndTables.forEach(schema -> {
+            LOGGER.info(schema.getName() + "\t\t" + schema.getTables().toString());
+        });
+        LOGGER.info("end...");
+    }
+
+    @Ignore
+    @Test
+    public void getTablesByDBTest() throws Exception {
+        Driver driver = getDriver();
+        driver.execute("use odsp ");
+        List<Table> tableList = driver.listTables(hiveDB);
+        tableList.forEach(schema -> {
+            LOGGER.info(schema.getName());
+        });
+        LOGGER.info("end...");
+    }
+
+    @Ignore
+    @Test
+    public void getColumnsByTableTest() {
+        Driver driver = getDriver();
+        List<Column> columns = driver.listColumns(hiveDB, "biz_college_planner_mysql_language_score_item");
+        for (Column column : columns) {
+            LOGGER.info(column.getName() + " \t " + column.getType() + " \t " + column.getComment());
+        }
+        LOGGER.info("end...");
+    }
+
+    @Ignore
+    @Test
+    public void getCreateTableTest() throws Exception {
+        Driver driver = getDriver();
+        Table driverTable = driver.getTable(hiveDB, "biz_college_planner_mysql_language_score_item");
+        String createTableSql = driver.getCreateTableSql(driverTable);
+        LOGGER.info(createTableSql);
+        LOGGER.info("end...");
+    }
+
+    @Ignore
+    @Test
+    public void getTableExtenedInfoTest() throws Exception {
+        Driver driver = getDriver();
+        Table driverTable = driver.getTable(hiveDB, "employees");
+        for (Column column : driverTable.getColumns()) {
+            LOGGER.info(column.getName() + "\t\t" + column.getType() + "\t\t" + column.getComment());
+        }
+    }
+
+    /**
+     * @Author: zhumingye
+     * @return:
+     */
+    @Ignore
+    @Test
+    public void multipleSQLTest() throws Exception {
+        Driver driver = getDriver();
+        String sql = "select\n"
+                + "   date_format(create_time,'yyyy-MM') as  pay_success_time,\n"
+                + "   sum(pay_amount)/100 as amount\n"
+                + "from\n"
+                + "    odsp.pub_pay_mysql_pay_order\n"
+                + "    group by date_format(create_time,'yyyy-MM') ;\n"
+                + "select\n"
+                + "   *\n"
+                + "from\n"
+                + "    odsp.pub_pay_mysql_pay_order ;";
+        JdbcSelectResult selectResult = driver.executeSql(sql, 100);
+        for (LinkedHashMap<String, Object> rowDatum : selectResult.getRowData()) {
+            Set<Map.Entry<String, Object>> entrySet = rowDatum.entrySet();
+            for (Map.Entry<String, Object> stringObjectEntry : entrySet) {
+                LOGGER.info(stringObjectEntry.getKey() + "\t\t" + stringObjectEntry.getValue());
+            }
+        }
+    }
+}

--- a/dinky-metadata/pom.xml
+++ b/dinky-metadata/pom.xml
@@ -42,6 +42,7 @@
         <module>dinky-metadata-hive</module>
         <module>dinky-metadata-starrocks</module>
         <module>dinky-metadata-presto</module>
+        <module>dinky-metadata-kyuubi</module>
     </modules>
 
     <dependencies>

--- a/dinky-web/src/pages/DataStudio/HeaderContainer/function.tsx
+++ b/dinky-web/src/pages/DataStudio/HeaderContainer/function.tsx
@@ -69,6 +69,7 @@ export const isSql = (dialect: string) => {
     case DIALECT.HIVE:
     case DIALECT.STARROCKS:
     case DIALECT.PRESTO:
+    case DIALECT.KYUUBI:
       return true;
     default:
       return false;

--- a/dinky-web/src/pages/DataStudio/LeftContainer/Project/constants.tsx
+++ b/dinky-web/src/pages/DataStudio/LeftContainer/Project/constants.tsx
@@ -174,6 +174,10 @@ export const JOB_TYPE: DefaultOptionType[] = [
       {
         value: 'Presto',
         label: 'Presto'
+      },
+      {
+        value: 'Kyuubi',
+        label: 'Kyuubi'
       }
     ]
   },

--- a/dinky-web/src/pages/RegCenter/DataSource/components/constants.ts
+++ b/dinky-web/src/pages/RegCenter/DataSource/components/constants.ts
@@ -67,6 +67,10 @@ export const DATA_SOURCE_TYPE_OPTIONS = [
       {
         label: 'Presto',
         value: 'Presto'
+      },
+      {
+        label: 'Kyuubi',
+        value: 'Kyuubi'
       }
     ]
   },
@@ -165,6 +169,11 @@ export const AUTO_COMPLETE_TYPE = [
     key: 'presto',
     value: 'jdbc:presto://localhost:8080/dinky',
     label: 'jdbc:presto://localhost:8080/dinky'
+  },
+  {
+    key: 'kyuubi',
+    value: 'jdbc:hive2://localhost:8080/default',
+    label: 'jdbc:hive2://localhost:8080/default'
   }
 ];
 

--- a/dinky-web/src/pages/RegCenter/DataSource/components/function.tsx
+++ b/dinky-web/src/pages/RegCenter/DataSource/components/function.tsx
@@ -59,6 +59,8 @@ export const renderDBIcon = (type: string, size?: number) => {
       return <StarRocksIcons size={size} />;
     case 'presto':
       return <PrestoIcons size={size} />;
+    case 'kyuubi':
+     return <PrestoIcons size={size} />;
     default:
       return <DefaultDBIcons size={size} />;
   }

--- a/dinky-web/src/services/constants.tsx
+++ b/dinky-web/src/services/constants.tsx
@@ -223,7 +223,8 @@ export const DIALECT = {
   HIVE: 'hive',
   PHOENIX: 'phoenix',
   STARROCKS: 'starrocks',
-  PRESTO: 'presto'
+  PRESTO: 'presto',
+  KYUUBI: 'kyuubi'
 };
 
 export const RUN_MODE = {

--- a/pom.xml
+++ b/pom.xml
@@ -931,9 +931,42 @@
     </scm>
     <repositories>
         <repository>
-            <snapshots />
-            <id>apache-snapshots</id>
+            <id>aliyun-central</id>
+            <url>https://maven.aliyun.com/repository/central</url>
+        </repository>
+        <repository>
+            <id>aliyun-public</id>
+            <url>https://maven.aliyun.com/repository/public</url>
+        </repository>
+        <repository>
+            <id>aliyun-snapshots</id>
             <url>https://maven.aliyun.com/repository/apache-snapshots</url>
+        </repository>
+        <repository>
+            <id>apache-spring-plugin</id>
+            <url>https://maven.aliyun.com/repository/spring-plugin</url>
+        </repository>
+        <repository>
+            <id>aliyun-spring</id>
+            <url>https://maven.aliyun.com/repository/spring</url>
+        </repository>
+        <repository>
+            <id>aliyun-google</id>
+            <url>https://maven.aliyun.com/repository/google</url>
+        </repository>
+        <repository>
+            <id>aliyun-gradle-plugin</id>
+            <url>https://maven.aliyun.com/repository/gradle-plugin</url>
+        </repository>
+
+        <repository>
+            <id>aliyun-jcenter</id>
+            <url>https://maven.aliyun.com/repository/jcenter</url>
+        </repository>
+
+        <repository>
+            <id>aliyun-releases</id>
+            <url>https://maven.aliyun.com/repository/releases</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## Purpose of the pull request

Using Kyuubi as the data source and Dinky in a role similar to Hue, it becomes very convenient to query and develop using various big data engines.

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
