### PR TITLE
[Optimization] Default value judgment for supplementary types

### DIFF
--- a/dinky-metadata/dinky-metadata-mysql/src/main/java/org/dinky/metadata/driver/MySqlDriver.java
+++ b/dinky-metadata/dinky-metadata-mysql/src/main/java/org/dinky/metadata/driver/MySqlDriver.java
@@ -114,7 +114,10 @@ public class MySqlDriver extends AbstractJdbcDriver {
                     final String dv = column.getDefaultValue();
                     // If it defaults to a numeric type, there is no need to include single quotes or a bit type
                     String defaultValueTag = " DEFAULT '%s'";
-                    if (NumberUtil.isNumber(dv) || columnType.startsWith("bit") || (StrUtil.isNotEmpty(dv) && dv.toLowerCase().trim().matches("^current_timestamp.*"))) {
+                    if (NumberUtil.isNumber(dv)
+                            || columnType.startsWith("bit")
+                            || (StrUtil.isNotEmpty(dv)
+                                    && dv.toLowerCase().trim().matches("^current_timestamp.*"))) {
                         defaultValueTag = " DEFAULT %s";
                     }
                     String defaultValue = Asserts.isNotNull(dv)

--- a/dinky-metadata/dinky-metadata-mysql/src/main/java/org/dinky/metadata/driver/MySqlDriver.java
+++ b/dinky-metadata/dinky-metadata-mysql/src/main/java/org/dinky/metadata/driver/MySqlDriver.java
@@ -114,7 +114,7 @@ public class MySqlDriver extends AbstractJdbcDriver {
                     final String dv = column.getDefaultValue();
                     // If it defaults to a numeric type, there is no need to include single quotes or a bit type
                     String defaultValueTag = " DEFAULT '%s'";
-                    if (NumberUtil.isNumber(dv) || columnType.startsWith("bit")) {
+                    if (NumberUtil.isNumber(dv) || columnType.startsWith("bit") || (StrUtil.isNotEmpty(dv) && dv.toLowerCase().trim().matches("^current_timestamp.*"))) {
                         defaultValueTag = " DEFAULT %s";
                     }
                     String defaultValue = Asserts.isNotNull(dv)


### PR DESCRIPTION
## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
