### PR TITLE
[Fix-3726][web] Fix the issue where the enable button in Git Project forms does not have a default value

### DIFF
--- a/dinky-web/src/pages/RegCenter/GitProject/components/ProjectModal/ProjectForm/index.tsx
+++ b/dinky-web/src/pages/RegCenter/GitProject/components/ProjectModal/ProjectForm/index.tsx
@@ -125,6 +125,7 @@ const ProjectForm: React.FC<ProjectFormProps> = (props) => {
             width='xs'
             name='enabled'
             label={l('global.table.isEnable')}
+            initialValue={false}
             {...SWITCH_OPTIONS()}
           />
         </ProForm.Group>


### PR DESCRIPTION
## Purpose of the pull request
Set a default value for enable switch in git project form
this close #3726 
## Brief change log
- Set a default value for enable switch in git project form
<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request
Manually verified the change by testing locally.
