### PR TITLE
fix(kubernetes-operator): Fix SavePoint path logic and adjust the configuration method of Flink configuration acquisition

### DIFF
--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
@@ -19,13 +19,6 @@
 
 package org.dinky.gateway.kubernetes.operator;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.dinky.assertion.Asserts;
 import org.dinky.data.enums.JobStatus;
 import org.dinky.gateway.enums.UpgradeMode;
@@ -37,13 +30,24 @@ import org.dinky.gateway.kubernetes.operator.api.FlinkDeploymentSpec;
 import org.dinky.gateway.kubernetes.operator.api.JobSpec;
 import org.dinky.gateway.result.SavePointResult;
 import org.dinky.gateway.result.TestResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
+
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -177,10 +181,8 @@ public abstract class KubernetesOperatorGateway extends KubernetesGateway {
     }
 
     // flink config defined key
-    private final List<String> flinkConfigDefinedByFlink = Lists.newArrayList(
-            "kubernetes.namespace",
-            "kubernetes.cluster-id"
-    );
+    private final List<String> flinkConfigDefinedByFlink =
+            Lists.newArrayList("kubernetes.namespace", "kubernetes.cluster-id");
 
     private void initSpec() {
         String flinkVersion = flinkConfig.getFlinkVersion();

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
@@ -163,9 +163,10 @@ public abstract class KubernetesOperatorGateway extends KubernetesGateway {
         String jbmem = flinkConfig.getConfiguration()
                 .getOrDefault("jobmanager.memory.process.size", "1G");
         logger.info("jobmanager resource is : cpu-->{}, mem-->{}", jbcpu, jbmem);
-        // jm ha kubernetes.jobmanager.replicas
-        int replicas = Integer.parseInt(flinkConfig.getConfiguration()
-                .getOrDefault("kubernetes.jobmanager.replicas", "1"));
+        // jm ha kubernetes.jobmanager.replicas or job flinkConfig
+        int replicas = Integer.parseInt(kubernetesConfiguration.getOrDefault("kubernetes.jobmanager.replicas",
+                flinkConfig.getConfiguration().getOrDefault("kubernetes.jobmanager.replicas", "1")));
+
         jobManagerSpec.setReplicas(replicas);
         jobManagerSpec.setResource(new Resource(Double.parseDouble(jbcpu), jbmem));
 

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
@@ -135,7 +135,7 @@ public abstract class KubernetesOperatorGateway extends KubernetesGateway {
             savePointPath = flinkConfig.getConfiguration().getOrDefault(savePointKey, null);
             logger.info("flinkConfig savePointPath: {}", savePointPath);
         }
-        // TODO: flink operator upgradeMode specifies savepointPath recovery and needs to be matched with savepointRedeployNonce this parameter.
+        // flink operator upgradeMode specifies savepointPath recovery and needs to be matched with savepointRedeployNonce this parameter.
         if (Asserts.isNotNull(savePointPath)) {
             /*
              * It is possible to redeploy a FlinkDeployment or FlinkSessionJob resource from a target savepoint

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
@@ -19,13 +19,6 @@
 
 package org.dinky.gateway.kubernetes.operator;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.dinky.assertion.Asserts;
 import org.dinky.data.enums.JobStatus;
 import org.dinky.gateway.enums.UpgradeMode;
@@ -37,13 +30,24 @@ import org.dinky.gateway.kubernetes.operator.api.FlinkDeploymentSpec;
 import org.dinky.gateway.kubernetes.operator.api.JobSpec;
 import org.dinky.gateway.result.SavePointResult;
 import org.dinky.gateway.result.TestResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
+
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -160,19 +164,18 @@ public abstract class KubernetesOperatorGateway extends KubernetesGateway {
         AbstractPodSpec jobManagerSpec = new AbstractPodSpec();
         AbstractPodSpec taskManagerSpec = new AbstractPodSpec();
         String jbcpu = kubernetesConfiguration.getOrDefault("kubernetes.jobmanager.cpu", "1");
-        String jbmem = flinkConfig.getConfiguration()
-                .getOrDefault("jobmanager.memory.process.size", "1G");
+        String jbmem = flinkConfig.getConfiguration().getOrDefault("jobmanager.memory.process.size", "1G");
         logger.info("jobmanager resource is : cpu-->{}, mem-->{}", jbcpu, jbmem);
         // jm ha kubernetes.jobmanager.replicas or job flinkConfig
-        int replicas = Integer.parseInt(kubernetesConfiguration.getOrDefault("kubernetes.jobmanager.replicas",
+        int replicas = Integer.parseInt(kubernetesConfiguration.getOrDefault(
+                "kubernetes.jobmanager.replicas",
                 flinkConfig.getConfiguration().getOrDefault("kubernetes.jobmanager.replicas", "1")));
 
         jobManagerSpec.setReplicas(replicas);
         jobManagerSpec.setResource(new Resource(Double.parseDouble(jbcpu), jbmem));
 
         String tmcpu = kubernetesConfiguration.getOrDefault("kubernetes.taskmanager.cpu", "1");
-        String tmmem = flinkConfig.getConfiguration()
-                .getOrDefault("taskmanager.memory.process.size", "1G");
+        String tmmem = flinkConfig.getConfiguration().getOrDefault("taskmanager.memory.process.size", "1G");
         logger.info("taskmanager resource is : cpu-->{}, mem-->{}", tmcpu, tmmem);
         taskManagerSpec.setResource(new Resource(Double.parseDouble(tmcpu), tmmem));
 

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
@@ -160,15 +160,18 @@ public abstract class KubernetesOperatorGateway extends KubernetesGateway {
         AbstractPodSpec jobManagerSpec = new AbstractPodSpec();
         AbstractPodSpec taskManagerSpec = new AbstractPodSpec();
         String jbcpu = kubernetesConfiguration.getOrDefault("kubernetes.jobmanager.cpu", "1");
-        String jbmem = flinkConfig.getConfiguration().getOrDefault("jobmanager.memory.process.size", "1G");
+        String jbmem = flinkConfig.getConfiguration()
+                .getOrDefault("jobmanager.memory.process.size", "1G");
         logger.info("jobmanager resource is : cpu-->{}, mem-->{}", jbcpu, jbmem);
         // jm ha kubernetes.jobmanager.replicas
-        int replicas = Integer.parseInt(flinkConfig.getConfiguration().getOrDefault("kubernetes.jobmanager.replicas", "1"));
+        int replicas = Integer.parseInt(flinkConfig.getConfiguration()
+                .getOrDefault("kubernetes.jobmanager.replicas", "1"));
         jobManagerSpec.setReplicas(replicas);
         jobManagerSpec.setResource(new Resource(Double.parseDouble(jbcpu), jbmem));
 
         String tmcpu = kubernetesConfiguration.getOrDefault("kubernetes.taskmanager.cpu", "1");
-        String tmmem = flinkConfig.getConfiguration().getOrDefault("taskmanager.memory.process.size", "1G");
+        String tmmem = flinkConfig.getConfiguration()
+                .getOrDefault("taskmanager.memory.process.size", "1G");
         logger.info("taskmanager resource is : cpu-->{}, mem-->{}", tmcpu, tmmem);
         taskManagerSpec.setResource(new Resource(Double.parseDouble(tmcpu), tmmem));
 

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
@@ -19,6 +19,13 @@
 
 package org.dinky.gateway.kubernetes.operator;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.dinky.assertion.Asserts;
 import org.dinky.data.enums.JobStatus;
 import org.dinky.gateway.enums.UpgradeMode;
@@ -30,24 +37,13 @@ import org.dinky.gateway.kubernetes.operator.api.FlinkDeploymentSpec;
 import org.dinky.gateway.kubernetes.operator.api.JobSpec;
 import org.dinky.gateway.result.SavePointResult;
 import org.dinky.gateway.result.TestResult;
-
-import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
-
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -166,6 +162,9 @@ public abstract class KubernetesOperatorGateway extends KubernetesGateway {
         String jbcpu = kubernetesConfiguration.getOrDefault("kubernetes.jobmanager.cpu", "1");
         String jbmem = flinkConfig.getConfiguration().getOrDefault("jobmanager.memory.process.size", "1G");
         logger.info("jobmanager resource is : cpu-->{}, mem-->{}", jbcpu, jbmem);
+        // jm ha kubernetes.jobmanager.replicas
+        int replicas = Integer.parseInt(flinkConfig.getConfiguration().getOrDefault("kubernetes.jobmanager.replicas", "1"));
+        jobManagerSpec.setReplicas(replicas);
         jobManagerSpec.setResource(new Resource(Double.parseDouble(jbcpu), jbmem));
 
         String tmcpu = kubernetesConfiguration.getOrDefault("kubernetes.taskmanager.cpu", "1");

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
@@ -176,7 +176,7 @@ public abstract class KubernetesOperatorGateway extends KubernetesGateway {
         flinkDeploymentSpec.setTaskManager(taskManagerSpec);
     }
 
-    // 不应被定义的 key
+    // flink config defined key
     private final List<String> flinkConfigDefinedByFlink = Lists.newArrayList(
             "kubernetes.namespace",
             "kubernetes.cluster-id"

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
@@ -135,7 +135,8 @@ public abstract class KubernetesOperatorGateway extends KubernetesGateway {
             savePointPath = flinkConfig.getConfiguration().getOrDefault(savePointKey, null);
             logger.info("flinkConfig savePointPath: {}", savePointPath);
         }
-        // flink operator upgradeMode specifies savepointPath recovery and needs to be matched with savepointRedeployNonce this parameter.
+        // flink operator upgradeMode specifies savepointPath recovery and needs to be matched
+        // with savepointRedeployNonce this parameter.
         if (Asserts.isNotNull(savePointPath)) {
             /*
              * It is possible to redeploy a FlinkDeployment or FlinkSessionJob resource from a target savepoint

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/IngressSpec.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/IngressSpec.java
@@ -21,37 +21,38 @@ package org.dinky.gateway.kubernetes.operator.api;
 
 import org.apache.flink.annotation.Experimental;
 
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressTLS;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 
+/** Ingress spec. */
 @Experimental
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString(callSuper = true)
-@SuperBuilder
+@Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class FlinkDeploymentSpec {
-    private JobSpec job;
-    private Long restartNonce;
-    /** Ingress specs. */
-    private IngressSpec ingress;
+public class IngressSpec {
 
-    private Map<String, String> flinkConfiguration;
-    private String image;
-    private String imagePullPolicy;
-    private String serviceAccount;
-    private String flinkVersion;
-    private Pod podTemplate;
-    private AbstractPodSpec jobManager;
-    private AbstractPodSpec taskManager;
-    private Map<String, String> logConfiguration;
+    /** Ingress template for the JobManager service. */
+    private String template;
+
+    /** Ingress className for the Flink deployment. */
+    private String className;
+
+    /** Ingress annotations. */
+    private Map<String, String> annotations;
+
+    /** Ingress labels. */
+    private Map<String, String> labels;
+
+    /** Ingress tls. */
+    private List<IngressTLS> tls;
 }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/IngressSpec.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/api/IngressSpec.java
@@ -32,7 +32,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/** Ingress spec. */
+/**
+ * Ingress spec.
+ * {@see https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-1.8/docs/operations/ingress/}
+ *
+ */
 @Experimental
 @Data
 @NoArgsConstructor

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/utils/K8sClientHelper.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/utils/K8sClientHelper.java
@@ -76,8 +76,8 @@ public class K8sClientHelper {
         Deployment deployment = kubernetesClient
                 .apps()
                 .deployments()
-                .inNamespace(configuration.getString(KubernetesConfigOptions.NAMESPACE))
-                .withName(configuration.getString(KubernetesConfigOptions.CLUSTER_ID))
+                .inNamespace(configuration.get(KubernetesConfigOptions.NAMESPACE))
+                .withName(configuration.get(KubernetesConfigOptions.CLUSTER_ID))
                 .get();
         if (deployment == null) {
             log.debug("Service {} does not exist", serviceName);
@@ -116,8 +116,8 @@ public class K8sClientHelper {
         Deployment deployment = kubernetesClient
                 .apps()
                 .deployments()
-                .inNamespace(configuration.getString(KubernetesConfigOptions.NAMESPACE))
-                .withName(configuration.getString(KubernetesConfigOptions.CLUSTER_ID))
+                .inNamespace(configuration.get(KubernetesConfigOptions.NAMESPACE))
+                .withName(configuration.get(KubernetesConfigOptions.CLUSTER_ID))
                 .get();
         List<HasMetadata> resources = getSqlFileDecorate().buildResources();
         // set owner reference


### PR DESCRIPTION
## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

- fixed kubernetes operator application 作业提交，savepoint 获取失败
-  rm `jobSpecBuilder.initialSavepointPath(savePointPath);` 参数， `flink application 模式` 导致启动失败
- add `kubernetes.jobmanager.replicas` jm ha replicas 高可用 
- add `ingressSpec` api ，提供 ingress 的 API 能力(仅添加)
- 通过 `AbstractGateway 属性 configuration`  获取 FlinkConfig 全部作业参数
- 通过相关 `*ConfigOptions` 获取 Flink 相关参数属性。

## Brief change log

- 默认从 flinkConfig 中读取 SavePoint 地址(优先使用作业提交的 Savepoint 地址配置)。
- rm `jobSpecBuilder.initialSavepointPath(savePointPath);`  导致作业启动失败。
- 调整了 Flink 配置优先级处理：
  1. 注册集群的配置为默认基础配置。`kubernetesConfiguration`
  2. SubmitJar 提交作业的参数(`flinkConfiguration`)，将合并或覆盖 `kubernetesConfiguration` 参数。
  3. 同时 Flink Operator 某些配置需要避免设定，例如 `kubernetes.namespace` 和 `kubernetes.cluster-id` 。
- 增加日志语句以更清晰地反映变量的使用。
- fixed flink operator on  application 模式 作业提交 HA 方式

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->


<img width="1642" alt="image" src="https://github.com/user-attachments/assets/291cfa71-1f52-4cd0-8861-5325e53f4ab6">


<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
