### PR TITLE
[Optimization] Improve get table info of the schema

### DIFF
--- a/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/AbstractDriver.java
+++ b/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/AbstractDriver.java
@@ -77,7 +77,7 @@ public abstract class AbstractDriver<T extends IConnectConfig> implements Driver
 
     @Override
     public Table getTable(String schemaName, String tableName) {
-        List<Table> tables = listTables(schemaName);
+        List<Table> tables = listTables(schemaName, tableName);
         Table table = null;
         for (Table item : tables) {
             if (Asserts.isEquals(item.getName(), tableName)) {

--- a/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/Driver.java
+++ b/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/driver/Driver.java
@@ -171,6 +171,8 @@ public interface Driver extends AutoCloseable {
 
     List<Table> listTables(String schemaName);
 
+    List<Table> listTables(String schemaName, String tableName);
+
     List<Column> listColumns(String schemaName, String tableName);
 
     List<Column> listColumnsSortByPK(String schemaName, String tableName);

--- a/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/query/IDBQuery.java
+++ b/dinky-metadata/dinky-metadata-base/src/main/java/org/dinky/metadata/query/IDBQuery.java
@@ -32,6 +32,9 @@ public interface IDBQuery {
     /** 表信息查询 SQL */
     String tablesSql(String schemaName);
 
+    /** 表信息查询 SQL */
+    String tablesSql(String schemaName, String tableName);
+
     /** 表字段信息查询 SQL */
     String columnsSql(String schemaName, String tableName);
 

--- a/dinky-metadata/dinky-metadata-base/src/test/java/org/dinky/metadata/driver/AbstractDriverTest.java
+++ b/dinky-metadata/dinky-metadata-base/src/test/java/org/dinky/metadata/driver/AbstractDriverTest.java
@@ -169,6 +169,11 @@ class AbstractDriverTest {
         }
 
         @Override
+        public List<Table> listTables(String schemaName, String tableName) {
+            return null;
+        }
+
+        @Override
         public List<Column> listColumns(String schemaName, String tableName) {
             return null;
         }

--- a/dinky-metadata/dinky-metadata-clickhouse/src/main/java/org/dinky/metadata/query/ClickHouseQuery.java
+++ b/dinky-metadata/dinky-metadata-clickhouse/src/main/java/org/dinky/metadata/query/ClickHouseQuery.java
@@ -44,6 +44,19 @@ public class ClickHouseQuery extends AbstractDBQuery {
     }
 
     /**
+     * 获取指定数据库下指定表的元数据
+     *
+     * @param schemaName 模式名称
+     * @param tableName 表名
+     * @return String
+     */
+    @Override
+    public String tablesSql(String schemaName, String tableName) {
+        return "select name, total_rows, engine, metadata_modification_time, comment "
+                + "from system.tables where 1=1 and database='" + schemaName + "' and name='" + tableName + "'";
+    }
+
+    /**
      * 从元数据表中获取表字段信息
      *
      * @param schemaName 模式名称

--- a/dinky-metadata/dinky-metadata-doris/src/main/java/org/dinky/metadata/constant/DorisConstant.java
+++ b/dinky-metadata/dinky-metadata-doris/src/main/java/org/dinky/metadata/constant/DorisConstant.java
@@ -36,6 +36,20 @@ public interface DorisConstant {
             + "from information_schema.tables"
             + " where"
             + " TABLE_SCHEMA = '%s'  ";
+
+    /** 查询schema下的指定表 */
+    String QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME = "select TABLE_NAME    AS `NAME`,\n" + "       TABLE_SCHEMA  AS `SCHEMA`,\n"
+            + "       TABLE_COMMENT AS COMMENT,\n"
+            + "       TABLE_TYPE            as TYPE,\n"
+            + "       TABLE_CATALOG            as CATALOG,\n"
+            + "       ENGINE            as ENGINE,\n"
+            + "       CREATE_OPTIONS            as OPTIONS,\n"
+            + "       TABLE_ROWS             as `ROWS`,\n"
+            + "       CREATE_TIME          as CREATE_TIME,\n"
+            + "       UPDATE_TIME          as UPDATE_TIME\n"
+            + "from information_schema.tables"
+            + " where"
+            + " TABLE_SCHEMA = '%s' and TABLE_NAME = '%s'";
     /** 查询指定schema.table下的所有列信息 */
     String QUERY_COLUMNS_BY_TABLE_AND_SCHEMA = "  show full columns from `%s`.`%s` ";
 

--- a/dinky-metadata/dinky-metadata-doris/src/main/java/org/dinky/metadata/constant/DorisConstant.java
+++ b/dinky-metadata/dinky-metadata-doris/src/main/java/org/dinky/metadata/constant/DorisConstant.java
@@ -38,18 +38,19 @@ public interface DorisConstant {
             + " TABLE_SCHEMA = '%s'  ";
 
     /** 查询schema下的指定表 */
-    String QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME = "select TABLE_NAME    AS `NAME`,\n" + "       TABLE_SCHEMA  AS `SCHEMA`,\n"
-            + "       TABLE_COMMENT AS COMMENT,\n"
-            + "       TABLE_TYPE            as TYPE,\n"
-            + "       TABLE_CATALOG            as CATALOG,\n"
-            + "       ENGINE            as ENGINE,\n"
-            + "       CREATE_OPTIONS            as OPTIONS,\n"
-            + "       TABLE_ROWS             as `ROWS`,\n"
-            + "       CREATE_TIME          as CREATE_TIME,\n"
-            + "       UPDATE_TIME          as UPDATE_TIME\n"
-            + "from information_schema.tables"
-            + " where"
-            + " TABLE_SCHEMA = '%s' and TABLE_NAME = '%s'";
+    String QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME =
+            "select TABLE_NAME    AS `NAME`,\n" + "       TABLE_SCHEMA  AS `SCHEMA`,\n"
+                    + "       TABLE_COMMENT AS COMMENT,\n"
+                    + "       TABLE_TYPE            as TYPE,\n"
+                    + "       TABLE_CATALOG            as CATALOG,\n"
+                    + "       ENGINE            as ENGINE,\n"
+                    + "       CREATE_OPTIONS            as OPTIONS,\n"
+                    + "       TABLE_ROWS             as `ROWS`,\n"
+                    + "       CREATE_TIME          as CREATE_TIME,\n"
+                    + "       UPDATE_TIME          as UPDATE_TIME\n"
+                    + "from information_schema.tables"
+                    + " where"
+                    + " TABLE_SCHEMA = '%s' and TABLE_NAME = '%s'";
     /** 查询指定schema.table下的所有列信息 */
     String QUERY_COLUMNS_BY_TABLE_AND_SCHEMA = "  show full columns from `%s`.`%s` ";
 

--- a/dinky-metadata/dinky-metadata-doris/src/main/java/org/dinky/metadata/query/DorisQuery.java
+++ b/dinky-metadata/dinky-metadata-doris/src/main/java/org/dinky/metadata/query/DorisQuery.java
@@ -37,6 +37,11 @@ public class DorisQuery extends AbstractDBQuery {
     }
 
     @Override
+    public String tablesSql(String schemaName, String tableName) {
+        return String.format(DorisConstant.QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME, schemaName, tableName);
+    }
+
+    @Override
     public String columnsSql(String schemaName, String tableName) {
         return String.format(DorisConstant.QUERY_COLUMNS_BY_TABLE_AND_SCHEMA, schemaName, tableName);
     }

--- a/dinky-metadata/dinky-metadata-hive/src/main/java/org/dinky/metadata/constant/HiveConstant.java
+++ b/dinky-metadata/dinky-metadata-hive/src/main/java/org/dinky/metadata/constant/HiveConstant.java
@@ -25,6 +25,8 @@ public interface HiveConstant {
     String QUERY_ALL_DATABASE = " show databases";
     /** 查询所有schema下的所有表 */
     String QUERY_ALL_TABLES_BY_SCHEMA = "show tables";
+    /** 查询所有schema下的所有表 */
+    String QUERY_ALL_TABLES_BY_SCHEMA_NAME_AND_TABLE_NAME = "show tables in %s like '%s'";
     /** 扩展信息Key */
     String DETAILED_TABLE_INFO = "Detailed Table Information";
     /** 查询指定schema.table的扩展信息 */

--- a/dinky-metadata/dinky-metadata-hive/src/main/java/org/dinky/metadata/driver/HiveDriver.java
+++ b/dinky-metadata/dinky-metadata-hive/src/main/java/org/dinky/metadata/driver/HiveDriver.java
@@ -50,7 +50,7 @@ public class HiveDriver extends AbstractJdbcDriver implements Driver {
 
     @Override
     public Table getTable(String schemaName, String tableName) {
-        List<Table> tables = listTables(schemaName);
+        List<Table> tables = listTables(schemaName, tableName);
         Table table = null;
         for (Table item : tables) {
             if (Asserts.isEquals(item.getName(), tableName)) {

--- a/dinky-metadata/dinky-metadata-hive/src/main/java/org/dinky/metadata/query/HiveQuery.java
+++ b/dinky-metadata/dinky-metadata-hive/src/main/java/org/dinky/metadata/query/HiveQuery.java
@@ -34,6 +34,11 @@ public class HiveQuery extends AbstractDBQuery {
     }
 
     @Override
+    public String tablesSql(String schemaName, String tableName) {
+        return String.format(HiveConstant.QUERY_ALL_TABLES_BY_SCHEMA_NAME_AND_TABLE_NAME, tableName);
+    }
+
+    @Override
     public String columnsSql(String schemaName, String tableName) {
         return String.format(HiveConstant.QUERY_TABLE_SCHEMA, schemaName, tableName);
     }

--- a/dinky-metadata/dinky-metadata-mysql/src/main/java/org/dinky/metadata/query/MySqlQuery.java
+++ b/dinky-metadata/dinky-metadata-mysql/src/main/java/org/dinky/metadata/query/MySqlQuery.java
@@ -43,6 +43,18 @@ public class MySqlQuery extends AbstractDBQuery {
     }
 
     @Override
+    public String tablesSql(String schemaName, String tableName) {
+        return "select TABLE_NAME AS `NAME`,TABLE_SCHEMA AS `Database`,TABLE_COMMENT AS"
+                + " COMMENT,TABLE_CATALOG AS `CATALOG`,TABLE_TYPE AS `TYPE`,ENGINE AS"
+                + " `ENGINE`,CREATE_OPTIONS AS `OPTIONS`,TABLE_ROWS AS"
+                + " `ROWS`,CREATE_TIME,UPDATE_TIME from information_schema.tables where"
+                + " TABLE_SCHEMA = '"
+                + schemaName + "' and TABLE_NAME ='"
+                + tableName
+                + "'";
+    }
+
+    @Override
     public String columnsSql(String schemaName, String tableName) {
         return "select COLUMN_NAME,COLUMN_TYPE,COLUMN_COMMENT,COLUMN_KEY,EXTRA AS AUTO_INCREMENT"
                 + ",COLUMN_DEFAULT,IS_NULLABLE,NUMERIC_PRECISION,NUMERIC_SCALE,CHARACTER_SET_NAME"

--- a/dinky-metadata/dinky-metadata-oracle/src/main/java/org/dinky/metadata/query/OracleQuery.java
+++ b/dinky-metadata/dinky-metadata-oracle/src/main/java/org/dinky/metadata/query/OracleQuery.java
@@ -36,6 +36,10 @@ public class OracleQuery extends AbstractDBQuery {
         return "SELECT * FROM ALL_TAB_COMMENTS WHERE OWNER='" + schemaName + "'";
     }
 
+    public String tablesSql(String schemaName, String tableName) {
+        return "SELECT * FROM ALL_TAB_COMMENTS WHERE OWNER='" + schemaName + "' AND TABLE_NAME='" + tableName + "'";
+    }
+
     @Override
     public String columnsSql(String schemaName, String tableName) {
         return "SELECT A.COLUMN_NAME, CASE WHEN A.DATA_TYPE='NUMBER' THEN (CASE WHEN"

--- a/dinky-metadata/dinky-metadata-paimon/src/main/java/org/dinky/metadata/driver/PaimonDriver.java
+++ b/dinky-metadata/dinky-metadata-paimon/src/main/java/org/dinky/metadata/driver/PaimonDriver.java
@@ -201,7 +201,10 @@ public class PaimonDriver extends AbstractDriver<PaimonConfig> {
     @Override
     public List<Table> listTables(String schemaName, String tableName) {
         try {
-            return catalog.listTables(schemaName).stream().filter(t -> t.equalsIgnoreCase(tableName)).map(Table::new).collect(Collectors.toList());
+            return catalog.listTables(schemaName).stream()
+                    .filter(t -> t.equalsIgnoreCase(tableName))
+                    .map(Table::new)
+                    .collect(Collectors.toList());
         } catch (Catalog.DatabaseNotExistException e) {
             throw new RuntimeException(e);
         }

--- a/dinky-metadata/dinky-metadata-paimon/src/main/java/org/dinky/metadata/driver/PaimonDriver.java
+++ b/dinky-metadata/dinky-metadata-paimon/src/main/java/org/dinky/metadata/driver/PaimonDriver.java
@@ -199,6 +199,15 @@ public class PaimonDriver extends AbstractDriver<PaimonConfig> {
     }
 
     @Override
+    public List<Table> listTables(String schemaName, String tableName) {
+        try {
+            return catalog.listTables(schemaName).stream().filter(t -> t.equalsIgnoreCase(tableName)).map(Table::new).collect(Collectors.toList());
+        } catch (Catalog.DatabaseNotExistException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
     public Table getTable(String schemaName, String tableName) {
         Identifier identifier = Identifier.create(schemaName, tableName);
         Table.TableBuilder tableBuilder = Table.builder();

--- a/dinky-metadata/dinky-metadata-paimon/src/main/java/org/dinky/metadata/query/PaimonQuery.java
+++ b/dinky-metadata/dinky-metadata-paimon/src/main/java/org/dinky/metadata/query/PaimonQuery.java
@@ -43,6 +43,18 @@ public class PaimonQuery extends AbstractDBQuery {
     }
 
     @Override
+    public String tablesSql(String schemaName, String tableName) {
+        return "select TABLE_NAME AS `NAME`,TABLE_SCHEMA AS `Database`,TABLE_COMMENT AS"
+                + " COMMENT,TABLE_CATALOG AS `CATALOG`,TABLE_TYPE AS `TYPE`,ENGINE AS"
+                + " `ENGINE`,CREATE_OPTIONS AS `OPTIONS`,TABLE_ROWS AS"
+                + " `ROWS`,CREATE_TIME,UPDATE_TIME from information_schema.tables where"
+                + " TABLE_SCHEMA = '"
+                + schemaName + "' and TABLE_NAME = '"
+                + tableName
+                + "'";
+    }
+
+    @Override
     public String columnsSql(String schemaName, String tableName) {
         return "select COLUMN_NAME,COLUMN_TYPE,COLUMN_COMMENT,COLUMN_KEY,EXTRA AS AUTO_INCREMENT"
                 + ",COLUMN_DEFAULT,IS_NULLABLE,NUMERIC_PRECISION,NUMERIC_SCALE,CHARACTER_SET_NAME"

--- a/dinky-metadata/dinky-metadata-phoenix/src/main/java/org/dinky/metadata/constant/PhoenixConstant.java
+++ b/dinky-metadata/dinky-metadata-phoenix/src/main/java/org/dinky/metadata/constant/PhoenixConstant.java
@@ -42,8 +42,8 @@ public interface PhoenixConstant {
     /** 根据schema查询table信息模板SQL */
     String QUERY_TABLE_BY_SCHEMA_SQL = QUERY_TABLE_BY_SCHEMA_SQL_DEFAULT + "  AND TABLE_SCHEM = '%s' ";
 
-    String QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME_SQL = QUERY_TABLE_BY_SCHEMA_SQL_DEFAULT + "  AND TABLE_SCHEM = '%s'"
-                                                           + " AND TABLE_NAME = '%s'";
+    String QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME_SQL =
+            QUERY_TABLE_BY_SCHEMA_SQL_DEFAULT + "  AND TABLE_SCHEM = '%s'" + " AND TABLE_NAME = '%s'";
 
     /** Phoenix的driver */
     String PHOENIX_DRIVER = "org.apache.phoenix.jdbc.PhoenixDriver";

--- a/dinky-metadata/dinky-metadata-phoenix/src/main/java/org/dinky/metadata/constant/PhoenixConstant.java
+++ b/dinky-metadata/dinky-metadata-phoenix/src/main/java/org/dinky/metadata/constant/PhoenixConstant.java
@@ -42,6 +42,9 @@ public interface PhoenixConstant {
     /** 根据schema查询table信息模板SQL */
     String QUERY_TABLE_BY_SCHEMA_SQL = QUERY_TABLE_BY_SCHEMA_SQL_DEFAULT + "  AND TABLE_SCHEM = '%s' ";
 
+    String QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME_SQL = QUERY_TABLE_BY_SCHEMA_SQL_DEFAULT + "  AND TABLE_SCHEM = '%s'"
+                                                           + " AND TABLE_NAME = '%s'";
+
     /** Phoenix的driver */
     String PHOENIX_DRIVER = "org.apache.phoenix.jdbc.PhoenixDriver";
 }

--- a/dinky-metadata/dinky-metadata-phoenix/src/main/java/org/dinky/metadata/query/PhoenixQuery.java
+++ b/dinky-metadata/dinky-metadata-phoenix/src/main/java/org/dinky/metadata/query/PhoenixQuery.java
@@ -37,6 +37,13 @@ public class PhoenixQuery extends AbstractDBQuery {
     }
 
     @Override
+    public String tablesSql(String schemaName, String tableName) {
+        if (schemaName == null || schemaName.isEmpty()) {
+            return PhoenixConstant.QUERY_TABLE_BY_SCHEMA_SQL_DEFAULT;
+        }
+        return String.format(PhoenixConstant.QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME_SQL, schemaName, tableName);
+    }
+    @Override
     public String columnsSql(String schemaName, String tableName) {
         if (schemaName == null || schemaName.isEmpty()) {
             return String.format(PhoenixConstant.QUERY_COLUMNS_SQL_DEFAULT, tableName);

--- a/dinky-metadata/dinky-metadata-phoenix/src/main/java/org/dinky/metadata/query/PhoenixQuery.java
+++ b/dinky-metadata/dinky-metadata-phoenix/src/main/java/org/dinky/metadata/query/PhoenixQuery.java
@@ -43,6 +43,7 @@ public class PhoenixQuery extends AbstractDBQuery {
         }
         return String.format(PhoenixConstant.QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME_SQL, schemaName, tableName);
     }
+
     @Override
     public String columnsSql(String schemaName, String tableName) {
         if (schemaName == null || schemaName.isEmpty()) {

--- a/dinky-metadata/dinky-metadata-postgresql/src/main/java/org/dinky/metadata/query/PostgreSqlQuery.java
+++ b/dinky-metadata/dinky-metadata-postgresql/src/main/java/org/dinky/metadata/query/PostgreSqlQuery.java
@@ -51,19 +51,19 @@ public class PostgreSqlQuery extends AbstractDBQuery {
     @Override
     public String tablesSql(String schemaName, String tableName) {
         return "SELECT n.nspname              AS schema_name\n"
-               + "     , c.relname              AS tablename\n"
-               + "     , obj_description(c.oid) AS comments\n"
-               + "     , c.reltuples            as rows\n"
-               + "FROM pg_class c\n"
-               + "         LEFT JOIN pg_namespace n ON n.oid = c.relnamespace\n"
-               + "WHERE ((c.relkind = 'r'::\"char\") OR (c.relkind = 'f'::\"char\") OR"
-               + " (c.relkind = 'p'::\"char\"))\n"
-               + "  AND n.nspname = '"
-               + schemaName + "'"
-               + " AND c.relname = '"
-               + tableName
-               + "'\n"
-               + "ORDER BY n.nspname, tablename";
+                + "     , c.relname              AS tablename\n"
+                + "     , obj_description(c.oid) AS comments\n"
+                + "     , c.reltuples            as rows\n"
+                + "FROM pg_class c\n"
+                + "         LEFT JOIN pg_namespace n ON n.oid = c.relnamespace\n"
+                + "WHERE ((c.relkind = 'r'::\"char\") OR (c.relkind = 'f'::\"char\") OR"
+                + " (c.relkind = 'p'::\"char\"))\n"
+                + "  AND n.nspname = '"
+                + schemaName + "'"
+                + " AND c.relname = '"
+                + tableName
+                + "'\n"
+                + "ORDER BY n.nspname, tablename";
     }
 
     @Override

--- a/dinky-metadata/dinky-metadata-postgresql/src/main/java/org/dinky/metadata/query/PostgreSqlQuery.java
+++ b/dinky-metadata/dinky-metadata-postgresql/src/main/java/org/dinky/metadata/query/PostgreSqlQuery.java
@@ -49,6 +49,24 @@ public class PostgreSqlQuery extends AbstractDBQuery {
     }
 
     @Override
+    public String tablesSql(String schemaName, String tableName) {
+        return "SELECT n.nspname              AS schema_name\n"
+               + "     , c.relname              AS tablename\n"
+               + "     , obj_description(c.oid) AS comments\n"
+               + "     , c.reltuples            as rows\n"
+               + "FROM pg_class c\n"
+               + "         LEFT JOIN pg_namespace n ON n.oid = c.relnamespace\n"
+               + "WHERE ((c.relkind = 'r'::\"char\") OR (c.relkind = 'f'::\"char\") OR"
+               + " (c.relkind = 'p'::\"char\"))\n"
+               + "  AND n.nspname = '"
+               + schemaName + "'"
+               + " AND c.relname = '"
+               + tableName
+               + "'\n"
+               + "ORDER BY n.nspname, tablename";
+    }
+
+    @Override
     public String columnsSql(String schemaName, String tableName) {
 
         return "SELECT col.column_name                                 as name\n"

--- a/dinky-metadata/dinky-metadata-presto/src/main/java/org/dinky/metadata/constant/PrestoConstant.java
+++ b/dinky-metadata/dinky-metadata-presto/src/main/java/org/dinky/metadata/constant/PrestoConstant.java
@@ -25,6 +25,8 @@ public interface PrestoConstant {
     String QUERY_ALL_DATABASE = "show catalogs";
     /** 查询某个schema下的所有表 */
     String QUERY_ALL_TABLES_BY_SCHEMA = "show tables from %s";
+    /** 查询某个schema下的指定表 */
+    String QUERY_SPECIFIED_TABLES_BY_SCHEMA = "show tables from %s like '%s'";
     /** 查询指定schema.table的信息 列 列类型 列注释 */
     String QUERY_TABLE_SCHEMA = " describe %s.%s";
     /** 只查询指定schema.table的列名 */

--- a/dinky-metadata/dinky-metadata-presto/src/main/java/org/dinky/metadata/driver/PrestoDriver.java
+++ b/dinky-metadata/dinky-metadata-presto/src/main/java/org/dinky/metadata/driver/PrestoDriver.java
@@ -51,7 +51,7 @@ public class PrestoDriver extends AbstractJdbcDriver implements Driver {
 
     @Override
     public Table getTable(String schemaName, String tableName) {
-        List<Table> tables = listTables(schemaName);
+        List<Table> tables = listTables(schemaName, tableName);
         Table table = null;
         for (Table item : tables) {
             if (Asserts.isEquals(item.getName(), tableName)) {

--- a/dinky-metadata/dinky-metadata-presto/src/main/java/org/dinky/metadata/query/PrestoQuery.java
+++ b/dinky-metadata/dinky-metadata-presto/src/main/java/org/dinky/metadata/query/PrestoQuery.java
@@ -30,9 +30,13 @@ public class PrestoQuery extends AbstractDBQuery {
 
     @Override
     public String tablesSql(String schemaName) {
-        return PrestoConstant.QUERY_ALL_TABLES_BY_SCHEMA;
+        return String.format(PrestoConstant.QUERY_ALL_TABLES_BY_SCHEMA, schemaName);
     }
 
+    @Override
+    public String tablesSql(String schemaName, String tableName) {
+        return String.format(PrestoConstant.QUERY_SPECIFIED_TABLES_BY_SCHEMA, schemaName, tableName);
+    }
     @Override
     public String columnsSql(String schemaName, String tableName) {
         return String.format(PrestoConstant.QUERY_TABLE_SCHEMA, schemaName, tableName);

--- a/dinky-metadata/dinky-metadata-presto/src/main/java/org/dinky/metadata/query/PrestoQuery.java
+++ b/dinky-metadata/dinky-metadata-presto/src/main/java/org/dinky/metadata/query/PrestoQuery.java
@@ -37,6 +37,7 @@ public class PrestoQuery extends AbstractDBQuery {
     public String tablesSql(String schemaName, String tableName) {
         return String.format(PrestoConstant.QUERY_SPECIFIED_TABLES_BY_SCHEMA, schemaName, tableName);
     }
+
     @Override
     public String columnsSql(String schemaName, String tableName) {
         return String.format(PrestoConstant.QUERY_TABLE_SCHEMA, schemaName, tableName);

--- a/dinky-metadata/dinky-metadata-sqlserver/src/main/java/org/dinky/metadata/constant/SqlServerConstant.java
+++ b/dinky-metadata/dinky-metadata-sqlserver/src/main/java/org/dinky/metadata/constant/SqlServerConstant.java
@@ -55,4 +55,10 @@ public interface SqlServerConstant {
             " SELECT  table_name ,table_schema, '' as type, '' as CATALOG, '' as ENGINE , '' as"
                     + " OPTIONS ,0 as rows , null as CREATE_TIME, null as UPDATE_TIME,null AS COMMENTS"
                     + "  FROM INFORMATION_SCHEMA.tables WHERE TABLE_SCHEMA  = '%s' ";
+
+    /** 根据schema查询table信息模板SQL */
+    String QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME_SQL =
+            " SELECT  table_name ,table_schema, '' as type, '' as CATALOG, '' as ENGINE , '' as"
+            + " OPTIONS ,0 as rows , null as CREATE_TIME, null as UPDATE_TIME,null AS COMMENTS"
+            + "  FROM INFORMATION_SCHEMA.tables WHERE TABLE_SCHEMA  = '%s' AND TABLE_NAME = '%s'";
 }

--- a/dinky-metadata/dinky-metadata-sqlserver/src/main/java/org/dinky/metadata/constant/SqlServerConstant.java
+++ b/dinky-metadata/dinky-metadata-sqlserver/src/main/java/org/dinky/metadata/constant/SqlServerConstant.java
@@ -59,6 +59,6 @@ public interface SqlServerConstant {
     /** 根据schema查询table信息模板SQL */
     String QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME_SQL =
             " SELECT  table_name ,table_schema, '' as type, '' as CATALOG, '' as ENGINE , '' as"
-            + " OPTIONS ,0 as rows , null as CREATE_TIME, null as UPDATE_TIME,null AS COMMENTS"
-            + "  FROM INFORMATION_SCHEMA.tables WHERE TABLE_SCHEMA  = '%s' AND TABLE_NAME = '%s'";
+                    + " OPTIONS ,0 as rows , null as CREATE_TIME, null as UPDATE_TIME,null AS COMMENTS"
+                    + "  FROM INFORMATION_SCHEMA.tables WHERE TABLE_SCHEMA  = '%s' AND TABLE_NAME = '%s'";
 }

--- a/dinky-metadata/dinky-metadata-sqlserver/src/main/java/org/dinky/metadata/query/SqlServerQuery.java
+++ b/dinky-metadata/dinky-metadata-sqlserver/src/main/java/org/dinky/metadata/query/SqlServerQuery.java
@@ -37,6 +37,11 @@ public class SqlServerQuery extends AbstractDBQuery {
     }
 
     @Override
+    public String tablesSql(String schemaName, String tableName) {
+        return String.format(SqlServerConstant.QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME_SQL, schemaName, tableName);
+    }
+
+    @Override
     public String columnsSql(String schemaName, String tableName) {
         return String.format(SqlServerConstant.QUERY_COLUMNS_SQL, tableName);
     }

--- a/dinky-metadata/dinky-metadata-starrocks/src/main/java/org/dinky/metadata/constant/StarRocksConstant.java
+++ b/dinky-metadata/dinky-metadata-starrocks/src/main/java/org/dinky/metadata/constant/StarRocksConstant.java
@@ -30,6 +30,14 @@ public interface StarRocksConstant {
                     + " TYPE, '' as CATALOG, '' as ENGINE , '' as OPTIONS , 0 as `ROWS`, null as"
                     + " CREATE_TIME, null as UPDATE_TIME from information_schema.tables where"
                     + " TABLE_SCHEMA = '%s'  ";
+
+    /** 查询schema下的指定表 */
+    String QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME =
+            " select TABLE_NAME AS `NAME`,TABLE_SCHEMA AS `SCHEMA`,TABLE_COMMENT AS COMMENT, '' as"
+            + " TYPE, '' as CATALOG, '' as ENGINE , '' as OPTIONS , 0 as `ROWS`, null as"
+            + " CREATE_TIME, null as UPDATE_TIME from information_schema.tables where"
+            + " TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'";
+
     /** 查询指定schema.table下的所有列信息 */
     String QUERY_COLUMNS_BY_TABLE_AND_SCHEMA = "  show full columns from `%s`.`%s` ";
 }

--- a/dinky-metadata/dinky-metadata-starrocks/src/main/java/org/dinky/metadata/constant/StarRocksConstant.java
+++ b/dinky-metadata/dinky-metadata-starrocks/src/main/java/org/dinky/metadata/constant/StarRocksConstant.java
@@ -34,9 +34,9 @@ public interface StarRocksConstant {
     /** 查询schema下的指定表 */
     String QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME =
             " select TABLE_NAME AS `NAME`,TABLE_SCHEMA AS `SCHEMA`,TABLE_COMMENT AS COMMENT, '' as"
-            + " TYPE, '' as CATALOG, '' as ENGINE , '' as OPTIONS , 0 as `ROWS`, null as"
-            + " CREATE_TIME, null as UPDATE_TIME from information_schema.tables where"
-            + " TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'";
+                    + " TYPE, '' as CATALOG, '' as ENGINE , '' as OPTIONS , 0 as `ROWS`, null as"
+                    + " CREATE_TIME, null as UPDATE_TIME from information_schema.tables where"
+                    + " TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'";
 
     /** 查询指定schema.table下的所有列信息 */
     String QUERY_COLUMNS_BY_TABLE_AND_SCHEMA = "  show full columns from `%s`.`%s` ";

--- a/dinky-metadata/dinky-metadata-starrocks/src/main/java/org/dinky/metadata/query/StarRocksQuery.java
+++ b/dinky-metadata/dinky-metadata-starrocks/src/main/java/org/dinky/metadata/query/StarRocksQuery.java
@@ -38,6 +38,11 @@ public class StarRocksQuery extends AbstractDBQuery {
     }
 
     @Override
+    public String tablesSql(String schemaName, String tableName) {
+        return String.format(StarRocksConstant.QUERY_TABLE_BY_SCHEMA_NAME_AND_TABLE_NAME, schemaName, tableName);
+    }
+
+    @Override
     public String columnsSql(String schemaName, String tableName) {
         return String.format(StarRocksConstant.QUERY_COLUMNS_BY_TABLE_AND_SCHEMA, schemaName, tableName);
     }


### PR DESCRIPTION
## Purpose of the pull request

At present, to query the information of a table, first obtain all the tables under the schema and then filter out the tables to be found, it is better to query only the information of the specified table directly from the database, which has better performance
## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
