### PR TITLE
[Feature][Data Studio]add getJobInstanceByTaskName api

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/controller/APIController.java
+++ b/dinky-admin/src/main/java/org/dinky/controller/APIController.java
@@ -174,6 +174,19 @@ public class APIController {
         return Result.succeed(jobInstanceService.getJobInstanceByTaskId(id));
     }
 
+    @GetMapping("/getJobInstanceByTaskName")
+    @ApiOperation("Get Job Instance By Task Id")
+    @ApiImplicitParam(
+            name = "id",
+            value = "Task Id",
+            required = true,
+            dataType = "Integer",
+            dataTypeClass = Integer.class)
+    public Result<JobInstance> getJobInstanceByTaskId(@RequestParam String taskName) {
+        taskService.initTenantByTaskName(taskName);
+        return Result.succeed(jobInstanceService.getJobInstanceByTaskName(taskName));
+    }
+
     @GetMapping(value = "/exportSql")
     @ApiOperation("Export Sql")
     @Log(title = "Export Sql", businessType = BusinessType.EXPORT)

--- a/dinky-admin/src/main/java/org/dinky/mapper/JobInstanceMapper.java
+++ b/dinky-admin/src/main/java/org/dinky/mapper/JobInstanceMapper.java
@@ -51,6 +51,8 @@ public interface JobInstanceMapper extends SuperMapper<JobInstance> {
 
     JobInstance getJobInstanceByTaskId(Integer id);
 
+    JobInstance getJobInstanceByTaskName(String taskName);
+
     @InterceptorIgnore(tenantLine = "true")
     Integer getTenantByJobInstanceId(@Param("id") Integer id);
 }

--- a/dinky-admin/src/main/java/org/dinky/mapper/TaskMapper.java
+++ b/dinky-admin/src/main/java/org/dinky/mapper/TaskMapper.java
@@ -53,6 +53,9 @@ public interface TaskMapper extends SuperMapper<Task> {
     @InterceptorIgnore(tenantLine = "true")
     Integer getTenantByTaskId(@Param("id") Integer id);
 
+    @InterceptorIgnore(tenantLine = "true")
+    Integer getTenantByTaskName(@Param("taskName") String taskName);
+
     List<JobTypeOverView> getTaskOnlineRate();
 
     JobModelOverview getJobStreamingOrBatchModelOverview();

--- a/dinky-admin/src/main/java/org/dinky/service/JobInstanceService.java
+++ b/dinky-admin/src/main/java/org/dinky/service/JobInstanceService.java
@@ -119,6 +119,8 @@ public interface JobInstanceService extends ISuperService<JobInstance> {
      */
     JobInstance getJobInstanceByTaskId(Integer id);
 
+    JobInstance getJobInstanceByTaskName(String taskName);
+
     /**
      * List all job instances in the system.
      *

--- a/dinky-admin/src/main/java/org/dinky/service/TaskService.java
+++ b/dinky-admin/src/main/java/org/dinky/service/TaskService.java
@@ -159,6 +159,12 @@ public interface TaskService extends ISuperService<Task> {
     void initTenantByTaskId(Integer id);
 
     /**
+     * Initialize the tenant by task name.
+     * @param taskName task name
+     */
+    void initTenantByTaskName(String taskName);
+
+    /**
      * Change the life cycle of the given task.
      *
      * @param taskId The ID of the task to change the life cycle for.

--- a/dinky-admin/src/main/java/org/dinky/service/impl/JobInstanceServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/JobInstanceServiceImpl.java
@@ -298,6 +298,11 @@ public class JobInstanceServiceImpl extends SuperServiceImpl<JobInstanceMapper, 
     }
 
     @Override
+    public JobInstance getJobInstanceByTaskName(String taskName) {
+        return baseMapper.getJobInstanceByTaskName(taskName);
+    }
+
+    @Override
     public ProTableResult<JobInstanceVo> listJobInstances(JsonNode para) {
         int current = para.has("current") ? para.get("current").asInt() : 1;
         int pageSize = para.has("pageSize") ? para.get("pageSize").asInt() : 10;

--- a/dinky-admin/src/main/java/org/dinky/service/impl/TaskServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/TaskServiceImpl.java
@@ -575,6 +575,14 @@ public class TaskServiceImpl extends SuperServiceImpl<TaskMapper, Task> implemen
     }
 
     @Override
+    public void initTenantByTaskName(String taskName) {
+        Integer tenantId = baseMapper.getTenantByTaskName(taskName);
+        Asserts.checkNull(tenantId, Status.TASK_NOT_EXIST.getMessage());
+        TenantContextHolder.set(tenantId);
+        log.info("Init task tenant finished..");
+    }
+
+    @Override
     @Transactional(rollbackFor = Exception.class)
     public boolean changeTaskLifeRecyle(Integer taskId, JobLifeCycle lifeCycle) throws SqlExplainExcepition {
         TaskDTO task = getTaskInfoById(taskId);

--- a/dinky-admin/src/main/resources/mapper/JobInstanceMapper.xml
+++ b/dinky-admin/src/main/resources/mapper/JobInstanceMapper.xml
@@ -98,6 +98,13 @@
         order by id desc limit 1
     </select>
 
+    <select id="getJobInstanceByTaskName" resultType="org.dinky.data.model.job.JobInstance">
+        select *
+        from dinky_job_instance
+        where name = #{taskName}
+        order by id desc limit 1
+    </select>
+
     <select id="getTenantByJobInstanceId" resultType="java.lang.Integer">
         select tenant_id
         from dinky_job_instance

--- a/dinky-admin/src/main/resources/mapper/TaskMapper.xml
+++ b/dinky-admin/src/main/resources/mapper/TaskMapper.xml
@@ -66,6 +66,12 @@
         where id = #{id}
     </select>
 
+    <select id="getTenantByTaskName" resultType="java.lang.Integer">
+        select tenant_id
+        from dinky_task
+        where name = #{taskName}
+    </select>
+
     <select id="queryOnLineTaskByDoneStatus" resultType="org.dinky.data.model.Task">
         select t.id as id, t.name as name
         from dinky_task t


### PR DESCRIPTION
## Purpose of the pull request

The job name is unique globally that can use to query the job instance, but the job id is not easy to remember

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
