### PR TITLE
[Fix]fix menu mapper

### DIFF
--- a/dinky-admin/src/main/resources/mapper/MenuMapper.xml
+++ b/dinky-admin/src/main/resources/mapper/MenuMapper.xml
@@ -102,7 +102,7 @@
         from dinky_sys_menu m
                  left join dinky_sys_role_menu rm on m.id = rm.menu_id
                  left join dinky_user_role ur on rm.role_id = ur.role_id
-                 left join dinky_role r on r.role_id = ur.role_id
+                 left join dinky_role r on r.id = ur.role_id
         where r.is_delete = 0 and ur.user_id = #{userId}
     </select>
 


### PR DESCRIPTION
## Purpose of the pull request

When select menu perms by userid,the sql execution error,because the field role_id does not exist in table dinky_role.
![图片](https://github.com/user-attachments/assets/143d6aab-d468-4523-87a2-f48e31acdd3a)


## Brief change log
The role_id in table dinky_role should be changed to id.
![图片](https://github.com/user-attachments/assets/b92559ec-a78e-4437-8f46-5e5035dab528)

