### PR TITLE
[hotfix][build] Fix Dinky backend CI workflow with Flink 1.20

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: true
       matrix:
         jdk: [8, 11]
-        flink: [1.14, 1.15, 1.16, 1.17, 1.18, 1.19, 1.20]
+        flink: ['1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20']
 
     timeout-minutes: 30
     env:


### PR DESCRIPTION
## Purpose of the pull request

This fixes Flink 1.20 packaging workflow isn't running as expected.

#3786 adds [Flink 1.20 packaging profile](https://github.com/DataLinkDC/dinky/commit/260932c5f9031c70e49fa0b9abcf8016ab7097cd#diff-e4844da8f91121f735157aa090f73b3b57317142673aaffa5c61d0a5a5731af8R130), however it isn't running as expected, since `1.20` is interpreted as a floating value in YAML, and it decays to `1.2` at runtime.

[CI workflows](https://github.com/DataLinkDC/dinky/actions/runs/11550792302/job/32146537751) targeting Flink 1.20 are actually running with the following configuration:

```
Run ./mvnw -B clean install \
  ./mvnw -B clean install \
          -Dmaven.test.skip=false \
         -Dspotless.check.skip=true \
         -Denforcer.skip=false \
         -Dmaven.javadoc.skip=true \
         -P prod,flink-single-version,flink-1.2,maven-central \
         --no-snapshot-updates
  shell: /usr/bin/bash -e {0}
  env:
    MAVEN_OPTS: -Xmx2G -Xms2G
    JAVA_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/8.0.432-6/x64
[INFO] Scanning for projects...
```

## Brief change log

Changing flink matrix argument to `'1.20'` (explicitly as string) should fix this issue.

## Verify this pull request

Ran backend CI tests in my own repo and it works as expected.