### PR TITLE
[Bug-4117][core]Bug fix for debug task when target table contains '.'

### DIFF
--- a/dinky-core/src/main/java/org/dinky/explainer/mock/MockStatementExplainer.java
+++ b/dinky-core/src/main/java/org/dinky/explainer/mock/MockStatementExplainer.java
@@ -165,14 +165,14 @@ public class MockStatementExplainer {
 
     /**
      * generate table identifier with mocked prefix info
-     * @param tableName table name
+     * @param tableIdentifier table identifier
      * @return table identifier with mocked prefix info
      */
-    private List<String> generateMockedTableIdentifier(String tableName) {
+    private List<String> generateMockedTableIdentifier(String tableIdentifier) {
         List<String> names = new ArrayList<>();
         names.add("default_catalog");
         names.add("default_database");
-        names.add("mock_sink_" + tableName);
+        names.add("mock_sink_" + tableIdentifier.replace(".", "_"));
         return names;
     }
 }


### PR DESCRIPTION
## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->
https://github.com/DataLinkDC/dinky/issues/4117
## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
![image](https://github.com/user-attachments/assets/bdf819a8-50b0-4819-8c34-7eb933e6c995)
