### PR TITLE
[Feature] Flink Kubernetes opoerator supports ingress

### DIFF
--- a/dinky-client/dinky-client-base/src/main/java/org/dinky/data/model/JarSubmitParam.java
+++ b/dinky-client/dinky-client-base/src/main/java/org/dinky/data/model/JarSubmitParam.java
@@ -106,4 +106,8 @@ public class JarSubmitParam {
                 getArgs(),
                 getAllowNonRestoredState());
     }
+
+    public String toString() {
+        return this.getStatement();
+    }
 }

--- a/dinky-web/src/pages/RegCenter/Cluster/Configuration/components/ConfigurationModal/ConfigurationForm/FlinkK8s/index.tsx
+++ b/dinky-web/src/pages/RegCenter/Cluster/Configuration/components/ConfigurationModal/ConfigurationForm/FlinkK8s/index.tsx
@@ -201,7 +201,7 @@ export default (props: {
               placeholder={l('rc.cc.flinkConfigPathPlaceholder')}
               tooltip={l('rc.cc.flinkConfigPathHelp')}
             />
-            {type && type === ClusterType.KUBERNETES_APPLICATION && (
+            {type && (type === ClusterType.KUBERNETES_APPLICATION || type === ClusterType.KUBERNETES_OPERATOR) && (
               <ProFormSwitch
                 name={['config', 'kubernetesConfig', 'ingressConfig', 'kubernetes.ingress.enabled']}
                 label={l('rc.cc.k8s.ingress.enabled')}
@@ -210,7 +210,7 @@ export default (props: {
                 unCheckedChildren={l('button.disable')}
               />
             )}
-            {type && type === ClusterType.KUBERNETES_APPLICATION && ingressEnabled && (
+            {type && (type === ClusterType.KUBERNETES_APPLICATION || type === ClusterType.KUBERNETES_OPERATOR) && ingressEnabled && (
               <ProFormText
                 tooltip={l('rc.cc.k8s.ingress.domainHelp')}
                 name={['config', 'kubernetesConfig', 'ingressConfig', 'kubernetes.ingress.domain']}


### PR DESCRIPTION
## Purpose of the pull request
﻿
Flink Kubernetes opoerator task supports ingress
﻿
## Brief change log
﻿
1. The Flink Kubernetes opoerator task has been launched on the page, which supports opening the ingress and entering the ingress domain name
2. Add the ingress related parameters to the k8s parameter in the backend
﻿
## Verify this pull request
﻿
This pull request is code cleanup without any test coverage.
﻿