### PR TITLE
[Bug-4149] Bug fix for web socket session do not closed correctly and page stuck caused by it

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/ws/GlobalWebSocket.java
+++ b/dinky-admin/src/main/java/org/dinky/ws/GlobalWebSocket.java
@@ -94,7 +94,9 @@ public class GlobalWebSocket {
     private static final Map<Session, RequestDTO> TOPICS = new ConcurrentHashMap<>();
 
     @OnOpen
-    public void onOpen(Session session) {}
+    public void onOpen(Session session) {
+        session.setMaxIdleTimeout(30000);
+    }
 
     @OnClose
     public void onClose(Session session) {

--- a/dinky-web/src/models/UseWebSocketModel.tsx
+++ b/dinky-web/src/models/UseWebSocketModel.tsx
@@ -119,9 +119,9 @@ export default () => {
         reconnect();
       } else {
         const currentTime = new Date().getTime();
-        if (currentTime - lastPongTimeRef.current > 15) {
+        if (currentTime - lastPongTimeRef.current > 15000) {
           reconnect();
-        } else if (currentTime - lastPongTimeRef.current > 5) {
+        } else if (currentTime - lastPongTimeRef.current > 5000) {
           const token = JSON.parse(localStorage.getItem(TOKEN_KEY) ?? '{}')?.tokenValue;
           ws.current.send(JSON.stringify({ token, type: 'PING' }));
         }

--- a/dinky-web/src/models/UseWebSocketModel.tsx
+++ b/dinky-web/src/models/UseWebSocketModel.tsx
@@ -59,7 +59,7 @@ export default () => {
   const ws = useRef<WebSocket>();
 
   const reconnect = () => {
-    if (ws.current && ws.current.readyState === WebSocket.CLOSED) {
+    if (ws.current && ws.current.readyState === WebSocket.OPEN) {
       ws.current.close();
     }
     ws.current = new WebSocket(wsUrl);
@@ -119,9 +119,9 @@ export default () => {
         reconnect();
       } else {
         const currentTime = new Date().getTime();
-        if (currentTime - lastPongTimeRef.current > 15000) {
+        if (currentTime - lastPongTimeRef.current > 15) {
           reconnect();
-        } else if (currentTime - lastPongTimeRef.current > 5000) {
+        } else if (currentTime - lastPongTimeRef.current > 5) {
           const token = JSON.parse(localStorage.getItem(TOKEN_KEY) ?? '{}')?.tokenValue;
           ws.current.send(JSON.stringify({ token, type: 'PING' }));
         }


### PR DESCRIPTION
## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->
https://github.com/DataLinkDC/dinky/issues/4149
## Brief change log

Front end: Bug fix for front end web socket close condition
Backend: Set max Idle time out for each session when opened
<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

If we add std out like follows:
![a6275c222d7af604b40f1e2f23dd7c6](https://github.com/user-attachments/assets/01d5abae-a9b9-4d65-942c-5b0ae4d74577)

In current version we can see that 
![4a92e6fa06f7e7ee0c83a609959d8a8](https://github.com/user-attachments/assets/f4b7b67f-3121-45b0-88ee-103c67249f27)
Sessions is keep creating and are not closed, when there are too many no closed sessions, page will be stuck.

After making the change like this PR,  sessions will be closed correctly, there will not be too many no closed sessions 
![74e95cd1034861bacb0f67e8cac95a6](https://github.com/user-attachments/assets/94eb2a20-11d0-4163-9064-9b023dc6db6e)

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
