### PR TITLE
[FixBug]fix 'Load kubernetes config failed' error

### DIFF
--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/KubernetesGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/KubernetesGateway.java
@@ -140,7 +140,6 @@ public abstract class KubernetesGateway extends AbstractGateway {
             resetCheckpointInApplicationMode(flinkConfig.getJobName());
         }
 
-        preparPodTemplate(k8sConfig.getKubeConfig(), KubernetesConfigOptions.KUBE_CONFIG_FILE);
         k8sClientHelper = new K8sClientHelper(configuration, k8sConfig.getKubeConfig());
 
         String sql = config.getSql();


### PR DESCRIPTION
当dinky和k8s不部署在同一它机器并且kubeconfig通过页面上提交(不使用默认文件)时，提交k8s的任务会报错，具体错误如下:
Caused by: java.lang.RuntimeException: {"type":"org.apache.flink.kubernetes.operator.exception.ReconciliationException","message":"org.apache.flink.kubernetes.shaded.io.fabric8.kubernetes.client.KubernetesClientException: Load kubernetes config failed.","additionalMetadata":{},"throwableList":[{"type":"org.apache.flink.kubernetes.shaded.io.fabric8.kubernetes.client.KubernetesClientException","message":"Load kubernetes config failed.","additionalMetadata":{}},{"type":"java.nio.file.NoSuchFileException","message":"/opt/dinky/tmp/kubernetes/b9975abc-978a-4b80-a372-ae33575323fb/kubernetes.config.file.yaml","additionalMetadata":{}}]}
错误显示kubernetes.config.file.yaml文件不存在，但是这个文件在dinky的机器上存在的，而这个文件不存在的位置其实是在k8s的机器上
根本原因是: 在提交k8s任务时，传递了kubernetes.config.file这个配置，存在这个配置会导致k8s机器通过这个配置来查找本地的k8s配置文件，所以这个配置不应该传递，对应k8s的机器，应该使用k8s自己配置的文件