### PR TITLE
[Optimization-4194] Display the timestamp type field as a string value when previewing data

### DIFF
--- a/dinky-core/src/main/java/org/dinky/data/result/ResultRunnable.java
+++ b/dinky-core/src/main/java/org/dinky/data/result/ResultRunnable.java
@@ -28,7 +28,9 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -57,6 +59,7 @@ public class ResultRunnable implements Runnable {
     private final boolean isAutoCancel;
     private final String timeZone;
     private BiConsumer<String, SelectResult> callback;
+    private static final DateTimeFormatter FORMATTER_CACHE = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     public ResultRunnable(
             TableResult tableResult,
@@ -164,9 +167,11 @@ public class ResultRunnable implements Runnable {
                         ((Instant) field)
                                 .atZone(ZoneId.of(timeZone))
                                 .toLocalDateTime()
-                                .toString());
+                                .format(FORMATTER_CACHE));
             } else if (field instanceof Boolean) {
                 map.put(column, field.toString());
+            } else if (field instanceof LocalDateTime) {
+                map.put(column, ((LocalDateTime) field).format(FORMATTER_CACHE));
             } else {
                 map.put(column, field);
             }


### PR DESCRIPTION

## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
