### PR TITLE
[bug][dinky-gateway] Fix the issue where two Flink configuration items with the same prefix cause errors in Flink configuration parsing.

### DIFF
--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/KubernetesGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/KubernetesGateway.java
@@ -47,6 +47,7 @@ import org.apache.flink.python.PythonOptions;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -102,17 +103,6 @@ public abstract class KubernetesGateway extends AbstractGateway {
                     + " is not Valid. In Kubernetes mode, task names must start and end with a lowercase letter or a digit, "
                     + "and can contain lowercase letters, digits, dots, and hyphens in between.");
         }
-        k8sConfig = config.getKubernetesConfig();
-
-        // Be compatible with kubernetes.container.image and kubernetes.container.image.ref
-        final String oldContainerImageKey = "kubernetes.container.image";
-        if (k8sConfig.getConfiguration().containsKey(oldContainerImageKey)) {
-            k8sConfig
-                    .getConfiguration()
-                    .put(
-                            KubernetesConfigOptions.CONTAINER_IMAGE.key(),
-                            k8sConfig.getConfiguration().get(oldContainerImageKey));
-        }
 
         configuration.set(CoreOptions.CLASSLOADER_RESOLVE_ORDER, "parent-first");
         try {
@@ -122,8 +112,17 @@ public abstract class KubernetesGateway extends AbstractGateway {
             logger.warn("load locale config yaml failed：{},Skip config it", e.getMessage());
         }
 
+        k8sConfig = config.getKubernetesConfig();
+        // 兼容kubernetes.container.image 和 kubernetes.container.image.ref
+        Map<String, String> k8sConfiguration = k8sConfig.getConfiguration();
+        final String oldContainerImageKey = "kubernetes.container.image";
+        if (k8sConfiguration.containsKey(oldContainerImageKey)) {
+            String containerImageValue = k8sConfiguration.get(oldContainerImageKey);
+            k8sConfiguration.remove(oldContainerImageKey);
+            k8sConfiguration.put(KubernetesConfigOptions.CONTAINER_IMAGE.key(), containerImageValue);
+        }
         // -------------------Note: the sequence can not be changed, priority problem----------------
-        addConfigParas(k8sConfig.getConfiguration());
+        addConfigParas(k8sConfiguration);
         addConfigParas(flinkConfig.getConfiguration());
         // -------------------------------------------
         addConfigParas(DeploymentOptions.TARGET, getType().getLongValue());


### PR DESCRIPTION
## Purpose of the pull request

[bug][dinky-gateway] Fix the issue where two Flink configuration items with the same prefix cause errors in Flink configuration parsing.

![image](https://github.com/user-attachments/assets/d5a0ef1a-60f1-4a03-9452-78a43932c0a6)
![5c09a02b7e2f97a3ac28bb420016165](https://github.com/user-attachments/assets/110bd8e1-06ef-4e53-8a44-bd96b82ed8f1)
![a6b88e45193f98f3699490e69d6e56c](https://github.com/user-attachments/assets/318df5ac-ff5e-40d3-bffd-296f8e4194e9)

The main change is the removal of k8sConfiguration.remove(oldContainerImageKey); to prevent YAML parsing failures caused by configuration items with the same prefix.
