### PR TITLE
[bug][dinky-gateway] Fix the issue where two Flink configuration items with the same prefix cause errors in Flink configuration parsing.

### DIFF
--- a/dinky-client/dinky-client-1.19/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
+++ b/dinky-client/dinky-client-1.19/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
@@ -154,7 +154,7 @@ public class FlinkConfMountDecorator extends AbstractKubernetesStepDecorator {
         clusterSideConfig.removeConfig(JobManagerOptions.BIND_HOST);
         clusterSideConfig.removeConfig(TaskManagerOptions.BIND_HOST);
         clusterSideConfig.removeConfig(TaskManagerOptions.HOST);
-        return ConfigurationUtils.convertConfigToWritableLines(clusterSideConfig, false);
+        return ConfigurationUtils.convertConfigToWritableLines(clusterSideConfig, true);
     }
 
     @VisibleForTesting

--- a/dinky-client/dinky-client-1.20/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
+++ b/dinky-client/dinky-client-1.20/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
@@ -154,7 +154,7 @@ public class FlinkConfMountDecorator extends AbstractKubernetesStepDecorator {
         clusterSideConfig.removeConfig(JobManagerOptions.BIND_HOST);
         clusterSideConfig.removeConfig(TaskManagerOptions.BIND_HOST);
         clusterSideConfig.removeConfig(TaskManagerOptions.HOST);
-        return ConfigurationUtils.convertConfigToWritableLines(clusterSideConfig, false);
+        return ConfigurationUtils.convertConfigToWritableLines(clusterSideConfig, true);
     }
 
     @VisibleForTesting

--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/KubernetesGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/KubernetesGateway.java
@@ -47,6 +47,7 @@ import org.apache.flink.python.PythonOptions;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -102,17 +103,6 @@ public abstract class KubernetesGateway extends AbstractGateway {
                     + " is not Valid. In Kubernetes mode, task names must start and end with a lowercase letter or a digit, "
                     + "and can contain lowercase letters, digits, dots, and hyphens in between.");
         }
-        k8sConfig = config.getKubernetesConfig();
-
-        // Be compatible with kubernetes.container.image and kubernetes.container.image.ref
-        final String oldContainerImageKey = "kubernetes.container.image";
-        if (k8sConfig.getConfiguration().containsKey(oldContainerImageKey)) {
-            k8sConfig
-                    .getConfiguration()
-                    .put(
-                            KubernetesConfigOptions.CONTAINER_IMAGE.key(),
-                            k8sConfig.getConfiguration().get(oldContainerImageKey));
-        }
 
         configuration.set(CoreOptions.CLASSLOADER_RESOLVE_ORDER, "parent-first");
         try {
@@ -122,8 +112,17 @@ public abstract class KubernetesGateway extends AbstractGateway {
             logger.warn("load locale config yaml failed：{},Skip config it", e.getMessage());
         }
 
+        k8sConfig = config.getKubernetesConfig();
+        // 兼容kubernetes.container.image 和 kubernetes.container.image.ref
+        Map<String, String> k8sConfiguration = k8sConfig.getConfiguration();
+        final String oldContainerImageKey = "kubernetes.container.image";
+        if (k8sConfiguration.containsKey(oldContainerImageKey)) {
+            String containerImageValue = k8sConfiguration.get(oldContainerImageKey);
+            k8sConfiguration.remove(oldContainerImageKey);
+            k8sConfiguration.put(KubernetesConfigOptions.CONTAINER_IMAGE.key(), containerImageValue);
+        }
         // -------------------Note: the sequence can not be changed, priority problem----------------
-        addConfigParas(k8sConfig.getConfiguration());
+        addConfigParas(k8sConfiguration);
         addConfigParas(flinkConfig.getConfiguration());
         // -------------------------------------------
         addConfigParas(DeploymentOptions.TARGET, getType().getLongValue());


### PR DESCRIPTION
## Purpose of the pull request

[bug][dinky-gateway] Fix the issue where two Flink configuration items with the same prefix cause errors in Flink configuration parsing.

![d22c3d55759f53ae6ea718264b35012](https://github.com/user-attachments/assets/55ce30e3-6438-4d26-abbc-4186069a3426)

In Dinky, all Flink configurations have already been parsed into a flattened YAML and passed into Kubernetes. However, due to Flink's source code re-parsing the already parsed YAML, this issue has arisen.