### PR TITLE
fix metadata-hive MissingFormatArgumentException #4316

### DIFF
--- a/dinky-metadata/dinky-metadata-hive/src/main/java/org/dinky/metadata/query/HiveQuery.java
+++ b/dinky-metadata/dinky-metadata-hive/src/main/java/org/dinky/metadata/query/HiveQuery.java
@@ -35,7 +35,7 @@ public class HiveQuery extends AbstractDBQuery {
 
     @Override
     public String tablesSql(String schemaName, String tableName) {
-        return String.format(HiveConstant.QUERY_ALL_TABLES_BY_SCHEMA_NAME_AND_TABLE_NAME, tableName);
+        return String.format(HiveConstant.QUERY_ALL_TABLES_BY_SCHEMA_NAME_AND_TABLE_NAME, schemaName, tableName);
     }
 
     @Override


### PR DESCRIPTION
## Purpose of the pull request

fix metadata-hive MissingFormatArgumentException #4316

## Brief change log
org.dinky.metadata.query.HiveQuery.tablesSql add "schemaName" , as shown below
![b6cb68d5e153891f46d3c25316378a1](https://github.com/user-attachments/assets/777cd71b-2d0b-420f-a5f2-ce2faf747696)

## Verify this pull request

This change added tests and can be verified as follows:

  - *Manually verified the change by testing locally.* 
1.register the hive data source In the registration center
2.browse table informance and SQL generation of hive data source on Data Development Center
![image](https://github.com/user-attachments/assets/532e3a76-c553-4efb-a466-5571e18ff09f)