### PR TITLE
[Bugfix] [k8s deployment] Modify the k8s deploy command

### DIFF
--- a/deploy/kubernetes/helm/dinky/templates/dinky.yaml
+++ b/deploy/kubernetes/helm/dinky/templates/dinky.yaml
@@ -97,7 +97,7 @@ spec:
             - /bin/bash
             - '-c'
             - >-
-              /opt/dinky/auto.sh startOnPending {{ .Values.spec.extraEnv.flinkVersion}}
+              /opt/dinky/bin/auto.sh startOnPending {{ .Values.spec.extraEnv.flinkVersion}}
           args:
           {{- if .Values.spec.livenessProbe.enabled }}
           livenessProbe:


### PR DESCRIPTION
I found the k8s deploy command use the error path, the 'auto.sh' is under the 'dinky/bin' path.