### PR TITLE
[Fix-4344] Fix dinky-release-1.20-1.2.3.jar lacks dinky-cdc-plus.jar

### DIFF
--- a/dinky-cdc/pom.xml
+++ b/dinky-cdc/pom.xml
@@ -53,5 +53,11 @@
                 <module>dinky-cdc-plus</module>
             </modules>
         </profile>
+        <profile>
+            <id>flink-1.20</id>
+            <modules>
+                <module>dinky-cdc-plus</module>
+            </modules>
+        </profile>
     </profiles>
 </project>

--- a/dinky-core/pom.xml
+++ b/dinky-core/pom.xml
@@ -429,5 +429,14 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>flink-1.20</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.dinky</groupId>
+                    <artifactId>dinky-cdc-plus</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION

## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
