### PR TITLE
[FixBug] Fix Exception on Convert.toInt of YarnGateway to track the new JobManager address in flink1.20

### DIFF
--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,8 +21,7 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.Column;
@@ -98,8 +97,7 @@ public class FlinkUtil {
                 .toString();
     }
 
-    public static int getZookeeperSessionTimeout(
-            Configuration configuration, ConfigOption<Integer> zookeeperSessionTimeout) {
-        return Convert.toInt(configuration.get(zookeeperSessionTimeout));
+    public static int getZookeeperSessionTimeout(Configuration configuration) {
+        return Convert.toInt(configuration.get(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT));
     }
 }

--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,8 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.Column;
@@ -30,6 +32,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+
+import cn.hutool.core.convert.Convert;
 
 /**
  * FlinkUtil
@@ -92,5 +96,10 @@ public class FlinkUtil {
                 .cancelWithSavepoint(JobID.fromHexString(jobId), savePoint)
                 .get()
                 .toString();
+    }
+
+    public static int getZookeeperSessionTimeout(
+            Configuration configuration, ConfigOption<Integer> zookeeperSessionTimeout) {
+        return Convert.toInt(configuration.get(zookeeperSessionTimeout));
     }
 }

--- a/dinky-client/dinky-client-1.14/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.14/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,7 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;

--- a/dinky-client/dinky-client-1.15/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.15/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,8 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -32,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+
+import cn.hutool.core.convert.Convert;
 
 /**
  * FlinkUtil
@@ -85,5 +89,10 @@ public class FlinkUtil {
                 .cancelWithSavepoint(JobID.fromHexString(jobId), savePoint, SavepointFormatType.DEFAULT)
                 .get()
                 .toString();
+    }
+
+    public static int getZookeeperSessionTimeout(
+            Configuration configuration, ConfigOption<Integer> zookeeperSessionTimeout) {
+        return Convert.toInt(configuration.get(zookeeperSessionTimeout));
     }
 }

--- a/dinky-client/dinky-client-1.15/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.15/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,8 +21,7 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -91,8 +90,7 @@ public class FlinkUtil {
                 .toString();
     }
 
-    public static int getZookeeperSessionTimeout(
-            Configuration configuration, ConfigOption<Integer> zookeeperSessionTimeout) {
-        return Convert.toInt(configuration.get(zookeeperSessionTimeout));
+    public static int getZookeeperSessionTimeout(Configuration configuration) {
+        return Convert.toInt(configuration.get(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT));
     }
 }

--- a/dinky-client/dinky-client-1.15/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.15/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,7 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;

--- a/dinky-client/dinky-client-1.16/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.16/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,8 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -32,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+
+import cn.hutool.core.convert.Convert;
 
 /**
  * FlinkUtil
@@ -85,5 +89,10 @@ public class FlinkUtil {
                 .cancelWithSavepoint(JobID.fromHexString(jobId), savePoint, SavepointFormatType.DEFAULT)
                 .get()
                 .toString();
+    }
+
+    public static int getZookeeperSessionTimeout(
+            Configuration configuration, ConfigOption<Integer> zookeeperSessionTimeout) {
+        return Convert.toInt(configuration.get(zookeeperSessionTimeout));
     }
 }

--- a/dinky-client/dinky-client-1.16/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.16/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,8 +21,7 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -91,8 +90,7 @@ public class FlinkUtil {
                 .toString();
     }
 
-    public static int getZookeeperSessionTimeout(
-            Configuration configuration, ConfigOption<Integer> zookeeperSessionTimeout) {
-        return Convert.toInt(configuration.get(zookeeperSessionTimeout));
+    public static int getZookeeperSessionTimeout(Configuration configuration) {
+        return Convert.toInt(configuration.get(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT));
     }
 }

--- a/dinky-client/dinky-client-1.16/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.16/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,7 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;

--- a/dinky-client/dinky-client-1.17/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.17/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,8 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -32,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+
+import cn.hutool.core.convert.Convert;
 
 /**
  * FlinkUtil
@@ -85,5 +89,10 @@ public class FlinkUtil {
                 .cancelWithSavepoint(JobID.fromHexString(jobId), savePoint, SavepointFormatType.DEFAULT)
                 .get()
                 .toString();
+    }
+
+    public static int getZookeeperSessionTimeout(
+            Configuration configuration, ConfigOption<Integer> zookeeperSessionTimeout) {
+        return Convert.toInt(configuration.get(zookeeperSessionTimeout));
     }
 }

--- a/dinky-client/dinky-client-1.17/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.17/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,8 +21,7 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -91,8 +90,7 @@ public class FlinkUtil {
                 .toString();
     }
 
-    public static int getZookeeperSessionTimeout(
-            Configuration configuration, ConfigOption<Integer> zookeeperSessionTimeout) {
-        return Convert.toInt(configuration.get(zookeeperSessionTimeout));
+    public static int getZookeeperSessionTimeout(Configuration configuration) {
+        return Convert.toInt(configuration.get(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT));
     }
 }

--- a/dinky-client/dinky-client-1.17/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.17/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,7 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;

--- a/dinky-client/dinky-client-1.18/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.18/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,8 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -32,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+
+import cn.hutool.core.convert.Convert;
 
 /**
  * FlinkUtil
@@ -85,5 +89,10 @@ public class FlinkUtil {
                 .cancelWithSavepoint(JobID.fromHexString(jobId), savePoint, SavepointFormatType.DEFAULT)
                 .get()
                 .toString();
+    }
+
+    public static int getZookeeperSessionTimeout(
+            Configuration configuration, ConfigOption<Integer> zookeeperSessionTimeout) {
+        return Convert.toInt(configuration.get(zookeeperSessionTimeout));
     }
 }

--- a/dinky-client/dinky-client-1.18/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.18/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,8 +21,7 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -91,8 +90,7 @@ public class FlinkUtil {
                 .toString();
     }
 
-    public static int getZookeeperSessionTimeout(
-            Configuration configuration, ConfigOption<Integer> zookeeperSessionTimeout) {
-        return Convert.toInt(configuration.get(zookeeperSessionTimeout));
+    public static int getZookeeperSessionTimeout(Configuration configuration) {
+        return Convert.toInt(configuration.get(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT));
     }
 }

--- a/dinky-client/dinky-client-1.18/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.18/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,7 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;

--- a/dinky-client/dinky-client-1.19/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.19/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,8 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -32,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+
+import cn.hutool.core.convert.Convert;
 
 /**
  * FlinkUtil
@@ -85,5 +89,10 @@ public class FlinkUtil {
                 .cancelWithSavepoint(JobID.fromHexString(jobId), savePoint, SavepointFormatType.DEFAULT)
                 .get()
                 .toString();
+    }
+
+    public static int getZookeeperSessionTimeout(
+            Configuration configuration, ConfigOption<Integer> zookeeperSessionTimeout) {
+        return Convert.toInt(configuration.get(zookeeperSessionTimeout));
     }
 }

--- a/dinky-client/dinky-client-1.19/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.19/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,8 +21,7 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -91,8 +90,7 @@ public class FlinkUtil {
                 .toString();
     }
 
-    public static int getZookeeperSessionTimeout(
-            Configuration configuration, ConfigOption<Integer> zookeeperSessionTimeout) {
-        return Convert.toInt(configuration.get(zookeeperSessionTimeout));
+    public static int getZookeeperSessionTimeout(Configuration configuration) {
+        return Convert.toInt(configuration.get(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT));
     }
 }

--- a/dinky-client/dinky-client-1.19/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.19/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,7 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;

--- a/dinky-client/dinky-client-1.20/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.20/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,8 +21,8 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -30,7 +30,6 @@ import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ContextResolvedTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -92,8 +91,10 @@ public class FlinkUtil {
                 .toString();
     }
 
-    public static int getZookeeperSessionTimeout(
-            Configuration configuration, ConfigOption<Duration> zookeeperSessionTimeout) {
-        return Convert.toInt(configuration.get(zookeeperSessionTimeout).getSeconds() * 1000);
+    public static int getZookeeperSessionTimeout(Configuration configuration) {
+        return Convert.toInt(configuration
+                        .get(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT)
+                        .getSeconds()
+                * 1000);
     }
 }

--- a/dinky-client/dinky-client-1.20/src/main/java/org/dinky/utils/FlinkUtil.java
+++ b/dinky-client/dinky-client-1.20/src/main/java/org/dinky/utils/FlinkUtil.java
@@ -21,6 +21,8 @@ package org.dinky.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -28,10 +30,13 @@ import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ContextResolvedTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+
+import cn.hutool.core.convert.Convert;
 
 /**
  * FlinkUtil
@@ -85,5 +90,10 @@ public class FlinkUtil {
                 .cancelWithSavepoint(JobID.fromHexString(jobId), savePoint, SavepointFormatType.DEFAULT)
                 .get()
                 .toString();
+    }
+
+    public static int getZookeeperSessionTimeout(
+            Configuration configuration, ConfigOption<Duration> zookeeperSessionTimeout) {
+        return Convert.toInt(configuration.get(zookeeperSessionTimeout).getSeconds() * 1000);
     }
 }

--- a/dinky-gateway/src/main/java/org/dinky/gateway/yarn/YarnGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/yarn/YarnGateway.java
@@ -39,6 +39,7 @@ import org.dinky.gateway.result.TestResult;
 import org.dinky.gateway.result.YarnResult;
 import org.dinky.gateway.utils.RequestKerberosUrlUtils;
 import org.dinky.utils.FlinkJsonUtil;
+import org.dinky.utils.FlinkUtil;
 import org.dinky.utils.ThreadUtil;
 
 import org.apache.commons.lang3.StringUtils;
@@ -94,7 +95,6 @@ import java.util.stream.Collectors;
 
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.collection.CollectionUtil;
-import cn.hutool.core.convert.Convert;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.lang.Assert;
 import cn.hutool.core.util.ReUtil;
@@ -513,7 +513,8 @@ public abstract class YarnGateway extends AbstractGateway {
                         + HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM.key()
                         + "'.");
             }
-            int sessionTimeout = Convert.toInt(configuration.get(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT));
+            int sessionTimeout = FlinkUtil.getZookeeperSessionTimeout(
+                    configuration, HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT);
             String root = configuration.getValue(HighAvailabilityOptions.HA_ZOOKEEPER_ROOT);
             String namespace = configuration.getValue(HighAvailabilityOptions.HA_CLUSTER_ID);
 

--- a/dinky-gateway/src/main/java/org/dinky/gateway/yarn/YarnGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/yarn/YarnGateway.java
@@ -513,8 +513,7 @@ public abstract class YarnGateway extends AbstractGateway {
                         + HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM.key()
                         + "'.");
             }
-            int sessionTimeout = FlinkUtil.getZookeeperSessionTimeout(
-                    configuration, HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT);
+            int sessionTimeout = FlinkUtil.getZookeeperSessionTimeout(configuration);
             String root = configuration.getValue(HighAvailabilityOptions.HA_ZOOKEEPER_ROOT);
             String namespace = configuration.getValue(HighAvailabilityOptions.HA_CLUSTER_ID);
 


### PR DESCRIPTION
## Purpose of the pull request

Fix dinky cannot track the JobManager address in yarn HA mode https://github.com/DataLinkDC/dinky/issues/4363

## Brief change log
Extract the zookeeper session timeout time acquisition method into the FlinkUtil class to avoid exceptions caused by different types of HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT in different versions of flink


1. YarnGateway changes：
<img width="1148" height="151" alt="image" src="https://github.com/user-attachments/assets/32ed3e7e-5957-44f9-9b82-0d1c579cfc18" />

2. FlinkUtil changes in all dinky-client versions：

(1)flink1.14-flink1.19:
<img width="1193" height="127" alt="image" src="https://github.com/user-attachments/assets/5f68d135-03fa-468b-ab36-da5ef4ed3ab8" />
(2)flink1.20:
<img width="1135" height="227" alt="image" src="https://github.com/user-attachments/assets/8b258375-3bab-48b8-be86-986884d7c6c9" />

## Verify this pull request

1. Configure high availability mode and ZooKeeper quorum in [Flink configuration file](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/deployment/config/#flink-configuration-file):
high-availability.type: zookeeper
high-availability.storageDir: hdfs:///flink/recovery
high-availability.zookeeper.quorum: address1:2181[,...],addressX:2181
2. Dinky submits the application mode job to yarn
4. Get Jobmanager address from FLINKwebui
![image](https://github.com/user-attachments/assets/849c9021-8761-4331-86a5-04ac56515726)

5. Stop JobManager(kill Jobmanager Process），After that , JobManager address will change
kill Jobmanager Process：
![image](https://github.com/user-attachments/assets/ddf97112-4382-4e69-b3a0-037d988cc8bf)
JobManager address will change Automatically:
![image](https://github.com/user-attachments/assets/3dd2ef4b-ab1b-4b2a-a615-b4c6e75377ae)