### PR TITLE
fix: A bug occurred when other sending methods were switched to corpo…

### DIFF
--- a/dinky-web/src/pages/RegCenter/Alert/AlertInstance/components/AlertTypeChoose/InstanceForm/WeChat/index.tsx
+++ b/dinky-web/src/pages/RegCenter/Alert/AlertInstance/components/AlertTypeChoose/InstanceForm/WeChat/index.tsx
@@ -86,6 +86,7 @@ const WeChat = (props: WeChatProps) => {
           label={l('rc.ai.sendType')}
           initialValue={sendType ?? 'app'}
           fieldProps={{
+            value: sendType,
             onChange: (e) => setSendType(e.target.value)
           }}
           options={[


### PR DESCRIPTION
![1](https://github.com/user-attachments/assets/93d4ffd1-4497-4f2a-9263-3525fb234f19)
![2](https://github.com/user-attachments/assets/19e6edf1-84fb-45a4-8d68-101a6e10a4cd)
![3](https://github.com/user-attachments/assets/8e9efbe3-2d62-452f-a90c-e1c443875523)

1.选择企业微信中发送方式为群聊，之后类型选择其他
2.切换为企业微信，此时发送方式依然为群聊，但下方表单为应用的表单