### PR TITLE
[Bug] Fix the token cannot be refreshed properly.

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -244,7 +244,7 @@ jobs:
       - name: Init k3s
         uses: nolar/setup-k3d-k3s@v1
         with:
-          version: latest
+          version: v1.21.2
           k3d-args: -s 1 --network dinky_net --api-port 172.28.0.1:6550
           k3d-tag: v5.7.5
       - name: Get k3s kube config

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -246,7 +246,6 @@ jobs:
         with:
           version: v1.21.2
           k3d-args: -s 1 --network dinky_net --api-port 172.28.0.1:6550
-          k3d-tag: v5.7.5
       - name: Get k3s kube config
         run: k3d kubeconfig get --all  && mkdir ./kube && k3d kubeconfig get --all >  ./kube/k3s.yaml && sed -i 's/0.0.0.0/172.28.0.1/g' ./kube/k3s.yaml
       - name: Init k8s RBAC and namespace

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -246,6 +246,7 @@ jobs:
         with:
           version: latest
           k3d-args: -s 1 --network dinky_net --api-port 172.28.0.1:6550
+          k3d-tag: v5.7.5
       - name: Get k3s kube config
         run: k3d kubeconfig get --all  && mkdir ./kube && k3d kubeconfig get --all >  ./kube/k3s.yaml && sed -i 's/0.0.0.0/172.28.0.1/g' ./kube/k3s.yaml
       - name: Init k8s RBAC and namespace

--- a/dinky-admin/src/main/java/org/dinky/controller/TokenController.java
+++ b/dinky-admin/src/main/java/org/dinky/controller/TokenController.java
@@ -62,6 +62,8 @@ import lombok.extern.slf4j.Slf4j;
 public class TokenController {
 
     private final TokenService tokenService;
+    private final org.dinky.service.impl.TokenService tokenServiceStp;
+
     private final StpLogic stpLogic;
 
     /**
@@ -92,9 +94,13 @@ public class TokenController {
             mode = SaMode.OR)
     public Result<Void> saveOrUpdateToken(@RequestBody SysToken sysToken) {
         sysToken.setSource(SysToken.Source.CUSTOM);
-        return tokenService.saveOrUpdate(sysToken)
+        Result<Void> result = tokenService.saveOrUpdate(sysToken)
                 ? Result.succeed(Status.SAVE_SUCCESS)
                 : Result.failed(Status.SAVE_FAILED);
+        if (result.isSuccess()) {
+            tokenServiceStp.injectToken(sysToken);
+        }
+        return result;
     }
 
     /**

--- a/dinky-admin/src/main/java/org/dinky/service/impl/TokenService.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/TokenService.java
@@ -300,27 +300,31 @@ public class TokenService implements SaTokenDao {
      */
     @Override
     public void init() {
-        DateTime now = DateUtil.date();
         List<SysToken> sysTokens = tokenMapper.selectList(new LambdaQueryWrapper<>());
         for (SysToken sysToken : sysTokens) {
-            Integer userId = sysToken.getUserId();
-            dataMap.put(stpLogic.splicingKeyTokenValue(sysToken.getTokenValue()), userId.toString());
-            dataMap.put(stpLogic.splicingKeyLastActiveTime(sysToken.getTokenValue()), StrUtil.toString(now.getTime()));
-            UserDTO userInfo = new UserDTO();
-            User user = new User();
-            user.setId(userId);
-            userInfo.setUser(user);
-            userInfo.setTenantList(Collections.singletonList(tenantMapper.selectById(sysToken.getTenantId())));
-            UserInfoContextHolder.set(userId, userInfo);
-            if (sysToken.getExpireType() == 1) {
-                expireMap.put(stpLogic.splicingKeyTokenValue(sysToken.getTokenValue()), NEVER_EXPIRE);
-            } else {
-                expireMap.put(
-                        stpLogic.splicingKeyTokenValue(sysToken.getTokenValue()),
-                        sysToken.getExpireEndTime().getTime());
-            }
+            injectToken(sysToken);
         }
         initRefreshThread();
+    }
+
+    public void injectToken(SysToken sysToken) {
+        DateTime now = DateUtil.date();
+        Integer userId = sysToken.getUserId();
+        dataMap.put(stpLogic.splicingKeyTokenValue(sysToken.getTokenValue()), userId.toString());
+        dataMap.put(stpLogic.splicingKeyLastActiveTime(sysToken.getTokenValue()), StrUtil.toString(now.getTime()));
+        UserDTO userInfo = new UserDTO();
+        User user = new User();
+        user.setId(userId);
+        userInfo.setUser(user);
+        userInfo.setTenantList(Collections.singletonList(tenantMapper.selectById(sysToken.getTenantId())));
+        UserInfoContextHolder.set(userId, userInfo);
+        if (sysToken.getExpireType() == 1) {
+            expireMap.put(stpLogic.splicingKeyTokenValue(sysToken.getTokenValue()), NEVER_EXPIRE);
+        } else {
+            expireMap.put(
+                    stpLogic.splicingKeyTokenValue(sysToken.getTokenValue()),
+                    sysToken.getExpireEndTime().getTime());
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request introduces enhancements to token management in the `TokenController` and `TokenService` classes. The changes focus on improving token injection logic, ensuring tokens are properly initialized, and refining the handling of token lifecycle events.

### Token injection and initialization improvements:

* [`dinky-admin/src/main/java/org/dinky/controller/TokenController.java`](diffhunk://#diff-7401a2b4646a83e499092b85329eb06dd547217d90a1726d3feb2754398f89d8R65-R66): Added a new `TokenService` instance (`tokenServiceStp`) to handle token injection. Updated the `saveOrUpdateToken` method to inject tokens into `tokenServiceStp` upon successful save or update operations. [[1]](diffhunk://#diff-7401a2b4646a83e499092b85329eb06dd547217d90a1726d3feb2754398f89d8R65-R66) [[2]](diffhunk://#diff-7401a2b4646a83e499092b85329eb06dd547217d90a1726d3feb2754398f89d8L95-R103)

* [`dinky-admin/src/main/java/org/dinky/service/impl/TokenService.java`](diffhunk://#diff-1aa3aab297cff2e85df3da2b5fd6d11dacceb0890538df1f848ee858186bed2bL303-R311): Introduced the `injectToken` method to centralize token injection logic. Updated the `init` method to call `injectToken` for all tokens during initialization. Removed redundant calls to `initRefreshThread` from the `init` method and relocated it to ensure proper initialization flow. [[1]](diffhunk://#diff-1aa3aab297cff2e85df3da2b5fd6d11dacceb0890538df1f848ee858186bed2bL303-R311) [[2]](diffhunk://#diff-1aa3aab297cff2e85df3da2b5fd6d11dacceb0890538df1f848ee858186bed2bL323-L324)