### PR TITLE
[Bug][dinky-web] Remove slash checks for jm url

### DIFF
--- a/dinky-web/src/locales/en-US/pages.ts
+++ b/dinky-web/src/locales/en-US/pages.ts
@@ -931,7 +931,6 @@ export default {
   'rc.ci.jmha.tips':
     'Add the RestApi address of the JobManager of the Flink cluster. In HA mode, the addresses are separated by commas, for example: 192.168.123.101:8081',
   'rc.ci.jmha.validate.port': 'Does not meet the rules! Port number range [0-65535]',
-  'rc.ci.jmha.validate.slash': 'Does not comply with the rules! Cannot contain /',
   'rc.ci.jmhaPlaceholder': 'Please enter the JobManager HA address!',
   'rc.ci.management': 'Cluster Instance Management',
   'rc.ci.modify': 'Modify cluster Instance',

--- a/dinky-web/src/locales/zh-CN/pages.ts
+++ b/dinky-web/src/locales/zh-CN/pages.ts
@@ -855,7 +855,6 @@ export default {
   'rc.ci.jmha.tips':
     '添加 Flink 集群的 JobManager 的 RestApi 地址。当 HA 模式时，地址间用英文逗号分隔，例如：192.168.123.101:8081',
   'rc.ci.jmha.validate.port': '不符合规则! 端口号区间[0-65535]',
-  'rc.ci.jmha.validate.slash': '不符合规则! 不能包含/',
   'rc.ci.jmhaPlaceholder': '请输入 JobManager HA 地址!',
   'rc.ci.management': '集群实例管理',
   'rc.ci.modify': '修改集群',

--- a/dinky-web/src/pages/DevOps/JobDetail/JobOperator/components/EditJobInstanceForm.tsx
+++ b/dinky-web/src/pages/DevOps/JobDetail/JobOperator/components/EditJobInstanceForm.tsx
@@ -18,7 +18,7 @@
  */
 
 import { CLUSTER_INSTANCE_TYPE } from '@/pages/RegCenter/Cluster/constants';
-import { validatorJMHAAdderess } from '@/pages/RegCenter/Cluster/Instance/components/function';
+import { validatorJMHAAddress } from '@/pages/RegCenter/Cluster/Instance/components/function';
 import { handleAddOrUpdate } from '@/services/BusinessCrud';
 import { API_CONSTANTS } from '@/services/endpoints';
 import { Jobs } from '@/types/DevOps/data';
@@ -97,7 +97,7 @@ const EditJobInstanceForm = (props: {
         rules={[
           {
             required: true,
-            validator: (rule, hostsValue) => validatorJMHAAdderess(rule, hostsValue)
+            validator: (rule, hostsValue) => validatorJMHAAddress(rule, hostsValue)
           }
         ]}
         placeholder={l('rc.ci.jmhaPlaceholder')}

--- a/dinky-web/src/pages/RegCenter/Cluster/Instance/components/InstanceModal/InstanceForm/index.tsx
+++ b/dinky-web/src/pages/RegCenter/Cluster/Instance/components/InstanceModal/InstanceForm/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { ClusterType, CLUSTER_INSTANCE_TYPE } from '@/pages/RegCenter/Cluster/constants';
-import { validatorJMHAAdderess } from '@/pages/RegCenter/Cluster/Instance/components/function';
+import { validatorJMHAAddress } from '@/pages/RegCenter/Cluster/Instance/components/function';
 import { Cluster } from '@/types/RegCenter/data.d';
 import { l } from '@/utils/intl';
 import {
@@ -82,7 +82,7 @@ const InstanceForm: React.FC<InstanceFormProps> = (props) => {
             rules={[
               {
                 required: true,
-                validator: (rule, hostsValue) => validatorJMHAAdderess(rule, hostsValue)
+                validator: (rule, hostsValue) => validatorJMHAAddress(rule, hostsValue)
               }
             ]}
             placeholder={l('rc.ci.jmhaPlaceholder')}

--- a/dinky-web/src/pages/RegCenter/Cluster/Instance/components/function.tsx
+++ b/dinky-web/src/pages/RegCenter/Cluster/Instance/components/function.tsx
@@ -27,20 +27,17 @@ import { RuleObject } from 'rc-field-form/es/interface';
 const { Text, Paragraph, Link } = Typography;
 
 /**
- * validatorJMHAAdderess
+ * validatorJMHAAddress
  * @param rule
  * @param value
  */
-export const validatorJMHAAdderess = (rule: RuleObject, value = '') => {
+export const validatorJMHAAddress = (rule: RuleObject, value = '') => {
   let hostArray = [];
   if (value.trim().length === 0) {
     return Promise.reject(new Error(l('rc.ci.jmhaPlaceholder')));
   } else {
     hostArray = value.split(',');
     for (let i = 0; i < hostArray.length; i++) {
-      if (hostArray[i].includes('/')) {
-        return Promise.reject(new Error(l('rc.ci.jmha.validate.slash')));
-      }
       if (parseInt(hostArray[i].split(':')[1]) >= 65535) {
         return Promise.reject(new Error(l('rc.ci.jmha.validate.port')));
       }


### PR DESCRIPTION
## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

Remove slash checks for jobManager address，Because it is correct to include slashes for the k8s-ingress address.

## Brief change log

* Remove slash checks for jm url.
* Fixed spelling errors.

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
