### PR TITLE
[Fix-3912][web] Fix the menu of subtype on document module does not refresh with document type

### DIFF
--- a/dinky-web/src/pages/RegCenter/Document/components/DocumentProTable/index.tsx
+++ b/dinky-web/src/pages/RegCenter/Document/components/DocumentProTable/index.tsx
@@ -43,6 +43,10 @@ import { ProTable } from '@ant-design/pro-components';
 import type { ActionType, ProColumns } from '@ant-design/pro-table';
 import TextArea from 'antd/es/input/TextArea';
 import React, { useRef, useState } from 'react';
+import { Select } from 'antd';
+import { JOB_TYPE } from '@/pages/DataStudio/Toolbar/Project/constants';
+
+const FUNCTION_TYPES = Object.values(DOCUMENT_FUNCTION_TYPE_ENUMS).map(item => ({ label: item.text, value: item.value }));
 
 const DocumentTableList: React.FC = () => {
   const [documentState, setDocumentState] = useState<DocumentState>(InitDocumentState);
@@ -123,7 +127,13 @@ const DocumentTableList: React.FC = () => {
       dataIndex: 'subtype',
       filters: true,
       filterMultiple: true,
-      valueEnum: DOCUMENT_FUNCTION_TYPE_ENUMS
+      renderFormItem: (item, { type }, form) => {
+        const currentType = form.getFieldValue('type');
+        let options = currentType === DOCUMENT_TYPE_ENUMS.FUN_UDF.value ? FUNCTION_TYPES :  JOB_TYPE;
+        return (
+          <Select allowClear options={options} />
+        );
+      },
     },
     {
       title: l('rc.doc.category'),


### PR DESCRIPTION
## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
