### PR TITLE
[Bug][k8s-operator] Remove CONF_DIR from FlinkConfiguration

### DIFF
--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
@@ -38,6 +38,7 @@ import org.dinky.gateway.result.TestResult;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.DeploymentOptionsInternal;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -207,8 +208,8 @@ public abstract class KubernetesOperatorGateway extends KubernetesGateway {
     }
 
     // flink config defined key
-    private final List<String> flinkConfigDefinedByFlink =
-            Lists.newArrayList("kubernetes.namespace", "kubernetes.cluster-id");
+    private final List<String> flinkConfigDefinedByFlink = Lists.newArrayList(
+            "kubernetes.namespace", "kubernetes.cluster-id", DeploymentOptionsInternal.CONF_DIR.key());
 
     private void initSpec() {
         String flinkVersion = flinkConfig.getFlinkVersion();


### PR DESCRIPTION
## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

* Remove the CONF_DIR configuration in KubernetesOperatorGateway, flink-kubernetes-operator will read the log4j.properties file from this configuration. If the directory does not match the location in the container, log4j.properties cannot be found（https://github.com/apache/flink-kubernetes-operator/blob/679b0337495693d84463584113bb50989e38a8bc/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java#L207）

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.
<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
