### PR TITLE
[Fix-4384][web] Fix the problem of task positioning error

### DIFF
--- a/.github/workflows/format_code.yaml
+++ b/.github/workflows/format_code.yaml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/setup-node@v3
         if: steps.filter.outputs.frontend == 'true'
         with:
-          node-version: 16
+          node-version: 18
       - name: Get npm cache directory
         id: npm-cache-dir
         if: steps.filter.outputs.frontend == 'true'
@@ -64,7 +64,7 @@ jobs:
           path: |
             ${{ steps.npm-cache-dir.outputs.dir }}
             dinky-web/dist
-          key: ${{ runner.os }}-node-${{ hashFiles('dinky-web/**/package.json') }}
+          key: ${{ runner.os }}-node18-${{ hashFiles('dinky-web/**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
       - name: Install Dependencies

--- a/dinky-web/src/pages/DataStudio/Toolbar/Project/index.tsx
+++ b/dinky-web/src/pages/DataStudio/Toolbar/Project/index.tsx
@@ -123,6 +123,10 @@ export const Project = (props: any) => {
   });
 
   useEffect(() => {
+    // Only execute if the directory tree has data
+    if (!data) {
+      return;
+    }
     switch (actionType) {
       // 折叠
       case DataStudioActionType.PROJECT_COLLAPSE_ALL:
@@ -152,14 +156,18 @@ export const Project = (props: any) => {
           'equal'
         );
         updateProject({ expandKeys: [...expandKeys, ...expandedKeys], selectedKeys: [params.key] });
-        treeRef.current!!.scrollTo({ key: params.key });
+        // Get the DirectoryTree component initialization status through treeData
+        // Only after initialization is completed, the following operations are performed
+        if (treeData && treeRef.current) {
+          treeRef.current.scrollTo({ key: params.key });
+        }
         break;
       case DataStudioActionType.PROJECT_REFRESH:
         setInitDid(true);
         refresh();
         break;
     }
-  }, [actionType, params]);
+  }, [actionType, params, data, treeData]);
 
   useAsyncEffect(async () => {
     if (data) {

--- a/dinky-web/src/pages/RegCenter/DataSource/components/DataSourceDetail/RightTagsRouter/index.tsx
+++ b/dinky-web/src/pages/RegCenter/DataSource/components/DataSourceDetail/RightTagsRouter/index.tsx
@@ -28,7 +28,12 @@ import { API_CONSTANTS } from '@/services/endpoints';
 import { PermissionConstants } from '@/types/Public/constants';
 import { DataSources } from '@/types/RegCenter/data';
 import { l } from '@/utils/intl';
-import {BookOutlined, ConsoleSqlOutlined, HighlightOutlined, SearchOutlined} from '@ant-design/icons';
+import {
+  BookOutlined,
+  ConsoleSqlOutlined,
+  HighlightOutlined,
+  SearchOutlined
+} from '@ant-design/icons';
 import { ProCardTabsProps } from '@ant-design/pro-card/es/typing';
 import { ProCard } from '@ant-design/pro-components';
 import { Space } from 'antd';


### PR DESCRIPTION
## Purpose of the pull request

This pull request fixes the problem of task positioning error in the DataStudio Project tree and improves code style consistency in the web module.

## Brief change log

- Fix task positioning error in DataStudio Project tree:
- Add null checks for directory tree data before executing positioning logic.
- Ensure scrollTo is only called after DirectoryTree initialization.
- Update useEffect dependencies to include data and treeData.
- Format the import statements for @ant-design/icons in RightTagsRouter for better readability.
- Update Node.js version from 16 to 18 in GitHub Actions workflow and adjust cache key accordingly.

## Verify this pull request

This pull request is code cleanup and bug fix without any new test coverage.
