### PR TITLE
[Fix-4385] Fix A bug occurred when other sending methods were switched

### DIFF
--- a/dinky-web/src/pages/RegCenter/Alert/AlertInstance/components/AlertTypeChoose/InstanceForm/WeChat/index.tsx
+++ b/dinky-web/src/pages/RegCenter/Alert/AlertInstance/components/AlertTypeChoose/InstanceForm/WeChat/index.tsx
@@ -86,6 +86,7 @@ const WeChat = (props: WeChatProps) => {
           label={l('rc.ai.sendType')}
           initialValue={sendType ?? 'app'}
           fieldProps={{
+            value: sendType,
             onChange: (e) => setSendType(e.target.value)
           }}
           options={[


### PR DESCRIPTION
## Purpose of the pull request

This pull request fixes a bug that occurred when switching between different sending methods in the WeChat alert configuration.

## Brief change log

- Add value property to fieldProps in ProFormRadio.Group component for WeChat alert type selection

## Verify this pull request

This pull request is already covered by existing tests, such as the existing alert configuration form tests and WeChat alert functionality tests.
(or)
This change can be verified as follows:
Manually verified the change by testing the WeChat alert configuration form locally
Verified that switching between 'app' and 'wechat' send types now works correctly without UI state issues
Confirmed that the radio button group properly maintains its selected value state
