### PR TITLE
[Optimize-3599][admin] CatalogueService add a new method findByTaskId

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/controller/CatalogueController.java
+++ b/dinky-admin/src/main/java/org/dinky/controller/CatalogueController.java
@@ -163,6 +163,28 @@ public class CatalogueController {
     }
 
     /**
+     * find catalogue by task id
+     * @param taskId task id
+     * @return {@link Result}< {@link Catalogue}>}
+     */
+    @GetMapping("/findByTaskId")
+    @ApiOperation("Find Catalogue By Task ID")
+    @ApiImplicitParam(
+            name = "taskId",
+            value = "taskId",
+            required = true,
+            dataType = "Integer",
+            dataTypeClass = Integer.class)
+    public Result<Catalogue> findByTaskId(@RequestParam Integer taskId) {
+        Catalogue catalogue = catalogueService.findByTaskId(taskId);
+        if (catalogue != null) {
+            return Result.succeed(catalogue);
+        } else {
+            return Result.failed(Status.CATALOGUE_NOT_EXIST);
+        }
+    }
+
+    /**
      * create catalogue and task
      * @param catalogueTaskDTO {@link CatalogueTaskDTO}
      * @return {@link Result}< {@link Catalogue}>}

--- a/dinky-admin/src/main/java/org/dinky/service/catalogue/CatalogueService.java
+++ b/dinky-admin/src/main/java/org/dinky/service/catalogue/CatalogueService.java
@@ -62,6 +62,14 @@ public interface CatalogueService extends ISuperService<Catalogue> {
     Catalogue findByParentIdAndName(Integer parentId, String name);
 
     /**
+     * Find a catalogue by its task ID.
+     *
+     * @param taskId The ID of the task to find the catalogue for.
+     * @return A {@link Catalogue} object representing the found catalogue, or null if not found.
+     */
+    Catalogue findByTaskId(Integer taskId);
+
+    /**
      * Save or update a catalogue and its tasks.
      *
      * @param catalogueTaskDTO A {@link CatalogueTaskDTO} object representing the updated catalogue and tasks.

--- a/dinky-admin/src/main/java/org/dinky/service/catalogue/impl/CatalogueServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/catalogue/impl/CatalogueServiceImpl.java
@@ -248,6 +248,12 @@ public class CatalogueServiceImpl extends SuperServiceImpl<CatalogueMapper, Cata
                 .eq(Catalogue::getName, name));
     }
 
+    @Override
+    public Catalogue findByTaskId(Integer taskId) {
+        return baseMapper.selectOne(new LambdaQueryWrapper<Catalogue>()
+                .eq(Catalogue::getTaskId, taskId));
+    }
+
     /**
      * check catalogue task name is exist
      *

--- a/dinky-admin/src/main/java/org/dinky/service/catalogue/impl/CatalogueServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/catalogue/impl/CatalogueServiceImpl.java
@@ -250,8 +250,7 @@ public class CatalogueServiceImpl extends SuperServiceImpl<CatalogueMapper, Cata
 
     @Override
     public Catalogue findByTaskId(Integer taskId) {
-        return baseMapper.selectOne(new LambdaQueryWrapper<Catalogue>()
-                .eq(Catalogue::getTaskId, taskId));
+        return baseMapper.selectOne(new LambdaQueryWrapper<Catalogue>().eq(Catalogue::getTaskId, taskId));
     }
 
     /**

--- a/dinky-admin/src/test/java/org/dinky/service/catalogue/impl/CatalogueServiceImplTest.java
+++ b/dinky-admin/src/test/java/org/dinky/service/catalogue/impl/CatalogueServiceImplTest.java
@@ -177,4 +177,47 @@ public class CatalogueServiceImplTest {
         catalogueServiceImplTest.importCatalogue(importCatalogueDto);
         verify(taskService, times(2)).saveBatch(anyList());
     }
+
+    @Test
+    public void findByTaskIdTest() {
+        // Given
+        Integer taskId = 123;
+        Catalogue expectedCatalogue = new Catalogue();
+        expectedCatalogue.setId(1);
+        expectedCatalogue.setName("Test Catalogue");
+        expectedCatalogue.setTaskId(taskId);
+        expectedCatalogue.setType("FlinkSQL");
+        expectedCatalogue.setParentId(0);
+        expectedCatalogue.setIsLeaf(true);
+
+        // Mock
+        when(catalogueMapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(expectedCatalogue);
+
+        // When
+        Catalogue result = catalogueServiceImplTest.findByTaskId(taskId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(expectedCatalogue.getId(), result.getId());
+        assertEquals(expectedCatalogue.getName(), result.getName());
+        assertEquals(expectedCatalogue.getTaskId(), result.getTaskId());
+        assertEquals(expectedCatalogue.getType(), result.getType());
+        assertEquals(expectedCatalogue.getParentId(), result.getParentId());
+        assertEquals(expectedCatalogue.getIsLeaf(), result.getIsLeaf());
+    }
+
+    @Test
+    public void findByTaskIdNotFoundTest() {
+        // Given
+        Integer taskId = 999;
+
+        // Mock - return null when catalogue not found
+        when(catalogueMapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(null);
+
+        // When
+        Catalogue result = catalogueServiceImplTest.findByTaskId(taskId);
+
+        // Then
+        assertNull(result);
+    }
 }


### PR DESCRIPTION
## Purpose of the pull request

This pull request adds a new method findByTaskId to CatalogueService to support finding catalogue information by task ID, as requested in issue #3599.

## Brief change log

- Add findByTaskId(Integer taskId) method to CatalogueService interface
- Implement findByTaskId method in CatalogueServiceImpl
- Add REST API endpoint /api/catalogue/findByTaskId in CatalogueController
- Add comprehensive test cases for the new functionality

## Verify this pull request

This change added tests and can be verified as follows:

- Added findByTaskIdTest to verify normal catalogue lookup by task ID
- Added findByTaskIdNotFoundTest to verify handling when catalogue is not found
- Added REST API endpoint with proper Swagger documentation
- Manually verified the API endpoint functionality by testing locally
- Verified error handling with CATALOGUE_NOT_EXIST status code

The implementation follows the existing code patterns and maintains backward compatibility while providing the requested functionality for third-party systems that only store taskId and need to retrieve catalogue information.

Powered by Claude Sonnet 4.
