### PR TITLE
[Fix-4419] Remove CONF_DIR from FlinkConfiguration

### DIFF
--- a/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
+++ b/dinky-gateway/src/main/java/org/dinky/gateway/kubernetes/operator/KubernetesOperatorGateway.java
@@ -36,6 +36,7 @@ import org.dinky.gateway.result.TestResult;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.DeploymentOptionsInternal;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -205,8 +206,8 @@ public abstract class KubernetesOperatorGateway extends KubernetesGateway {
     }
 
     // flink config defined key
-    private final List<String> flinkConfigDefinedByFlink =
-            Lists.newArrayList("kubernetes.namespace", "kubernetes.cluster-id");
+    private final List<String> flinkConfigDefinedByFlink = Lists.newArrayList(
+            "kubernetes.namespace", "kubernetes.cluster-id", DeploymentOptionsInternal.CONF_DIR.key());
 
     private void initSpec() {
         String flinkVersion = flinkConfig.getFlinkVersion();


### PR DESCRIPTION
## Purpose of the pull request

Remove the CONF_DIR configuration item from the Flink configuration in Kubernetes Operator mode to avoid issues where log4j.properties cannot be loaded correctly due to path inconsistencies.

## Brief change log

- Add DeploymentOptionsInternal.CONF_DIR.key() to the flinkConfigDefinedByFlink filter list in KubernetesOperatorGateway, ensuring that the generated FlinkDeploymentSpec does not contain the CONF_DIR configuration item.

## Verify this pull request

This pull request is code cleanup without any test coverage.
