### PR TITLE
[Bug][To 1.2] Ignore tenant conditions when refreshing a job

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/job/handler/JobRefreshHandler.java
+++ b/dinky-admin/src/main/java/org/dinky/job/handler/JobRefreshHandler.java
@@ -194,6 +194,9 @@ public class JobRefreshHandler {
 
         isDone = !isTransition && isDone;
 
+        //we use jobInstanceId get info and update, ignore tenant ，Otherwise, it will cause tenant condition filtering errors
+        TenantContextHolder.ignoreTenant();
+
         if (!oldStatus.equals(jobInstance.getStatus()) || isDone || needSave) {
             log.debug("Dump JobInfo to database: {}->{}", jobInstance.getId(), jobInstance.getName());
             if (jobInstance.getStatus().equals(JobStatus.UNKNOWN.getValue())

--- a/dinky-admin/src/main/java/org/dinky/job/handler/JobRefreshHandler.java
+++ b/dinky-admin/src/main/java/org/dinky/job/handler/JobRefreshHandler.java
@@ -194,7 +194,8 @@ public class JobRefreshHandler {
 
         isDone = !isTransition && isDone;
 
-        //we use jobInstanceId get info and update, ignore tenant ，Otherwise, it will cause tenant condition filtering errors
+        // we use jobInstanceId get info and update, ignore tenant ，Otherwise, it will cause tenant condition filtering
+        // errors
         TenantContextHolder.ignoreTenant();
 
         if (!oldStatus.equals(jobInstance.getStatus()) || isDone || needSave) {


### PR DESCRIPTION
- Add logic to ignore tenant conditions in the JobRefreshHandler
- Prevents filtering errors due to tenant conditions when refreshing jobs

## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
