### PR TITLE
[dinky-client] Fix the issue of Flink job archive path error when usi…

### DIFF
--- a/dinky-client/dinky-client-base/src/main/java/org/dinky/resource/BaseResourceManager.java
+++ b/dinky-client/dinky-client-base/src/main/java/org/dinky/resource/BaseResourceManager.java
@@ -155,6 +155,9 @@ public interface BaseResourceManager {
         if (!basePath.endsWith("/")) {
             basePath += "/";
         }
+        if (!basePath.startsWith("/")) {
+            basePath = "/" + basePath;
+        }
         return basePath;
     }
 }


### PR DESCRIPTION
当使用 OSS 作为资源存储时，会出现如下报错。rs 是配置的上传目录的根路径。错误的原因在于生成的路径是相对路径，而相对路径会被判断为不存在。如果将上传目录的根路径以 '/' 开头，可以避免该错误，但会导致 Flink 无法启动。为解决这个问题，应在生成根路径时判断其是否以 '/' 开头，如果不是，则自动在前面添加 '/'。

[dinky] 2025-08-25 17:25:01 CST ERROR org.apache.flink.runtime.webmonitor.history.HistoryServerArchiveFetcher 232 fetchArchives - Critical failure while fetching/processing job archives. java.lang.IllegalArgumentException: Path is not absolute: rs/tmp/flink-job-archive
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:218) ~[guava-32.1.3-jre.jar:?]
	at com.facebook.presto.hive.s3.PrestoS3FileSystem.keyFromPath(PrestoS3FileSystem.java:724) ~[flink-s3-fs-presto-1.18.0.jar:1.18.0]
	at com.facebook.presto.hive.s3.PrestoS3FileSystem.getS3ObjectMetadata(PrestoS3FileSystem.java:647) ~[flink-s3-fs-presto-1.18.0.jar:1.18.0]
	at com.facebook.presto.hive.s3.PrestoS3FileSystem.getFileStatus(PrestoS3FileSystem.java:353) ~[flink-s3-fs-presto-1.18.0.jar:1.18.0]
	at org.apache.hadoop.fs.FileSystem.exists(FileSystem.java:1760) ~[flink-s3-fs-presto-1.18.0.jar:1.18.0]
	at org.apache.flink.fs.s3presto.common.HadoopFileSystem.exists(HadoopFileSystem.java:165) ~[flink-s3-fs-presto-1.18.0.jar:1.18.0]
	at org.dinky.url.ResourceFileSystem.listStatus(ResourceFileSystem.java:99) ~[dinky-client-base-1.3.0-SNAPSHOT.jar:?]
	at org.apache.flink.runtime.webmonitor.history.HistoryServerArchiveFetcher.listArchives(HistoryServerArchiveFetcher.java:239) ~[flink-dist-1.18.0.jar:1.18.0]
	at org.apache.flink.runtime.webmonitor.history.HistoryServerArchiveFetcher.fetchArchives(HistoryServerArchiveFetcher.java:170) ~[flink-dist-1.18.0.jar:1.18.0]
	at org.apache.flink.runtime.webmonitor.history.HistoryServer.lambda$getArchiveFetchingRunnable$3(HistoryServer.java:329) ~[flink-dist-1.18.0.jar:1.18.0]
	at org.apache.flink.runtime.util.Runnables.lambda$withUncaughtExceptionHandler$0(Runnables.java:49) ~[flink-dist-1.18.0.jar:1.18.0]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
