### PR TITLE
[dinky-admin] Fix issue where a job is still running but Dinky shows …

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/init/SystemInit.java
+++ b/dinky-admin/src/main/java/org/dinky/init/SystemInit.java
@@ -36,6 +36,7 @@ import org.dinky.function.constant.PathConstant;
 import org.dinky.function.pool.UdfCodePool;
 import org.dinky.job.ClearJobHistoryTask;
 import org.dinky.job.FlinkJobTask;
+import org.dinky.job.RecheckJobTask;
 import org.dinky.resource.BaseResourceManager;
 import org.dinky.scheduler.client.ProjectClient;
 import org.dinky.scheduler.exception.SchedulerException;
@@ -159,6 +160,9 @@ public class SystemInit implements ApplicationRunner {
         // Init clear job history task
         DaemonTask clearJobHistoryTask = DaemonTask.build(new DaemonTaskConfig(ClearJobHistoryTask.TYPE));
         schedule.addSchedule(clearJobHistoryTask, new PeriodicTrigger(1, TimeUnit.HOURS));
+
+        DaemonTask recheckJobTask = DaemonTask.build(new DaemonTaskConfig(RecheckJobTask.TYPE));
+        schedule.addSchedule(recheckJobTask, new PeriodicTrigger(5, TimeUnit.MINUTES));
 
         // Add flink running job task to flink job thread pool
         List<JobInstance> jobInstances = jobInstanceService.listJobInstanceActive();

--- a/dinky-admin/src/main/java/org/dinky/job/RecheckJobTask.java
+++ b/dinky-admin/src/main/java/org/dinky/job/RecheckJobTask.java
@@ -1,0 +1,126 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.dinky.job;
+
+import org.dinky.api.FlinkAPI;
+import org.dinky.context.SpringContextUtils;
+import org.dinky.daemon.pool.FlinkJobThreadPool;
+import org.dinky.daemon.task.DaemonTask;
+import org.dinky.daemon.task.DaemonTaskConfig;
+import org.dinky.data.enums.JobStatus;
+import org.dinky.data.model.ext.JobInfoDetail;
+import org.dinky.data.model.job.JobInstance;
+import org.dinky.service.JobInstanceService;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.context.annotation.DependsOn;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@DependsOn("springContextUtils")
+@Slf4j
+@Data
+public class RecheckJobTask implements DaemonTask {
+
+    public static final String TYPE = RecheckJobTask.class.toString();
+
+    private DaemonTaskConfig config;
+
+    private static JobInstanceService jobInstanceService;
+
+    static {
+        jobInstanceService = SpringContextUtils.getBean("jobInstanceServiceImpl", JobInstanceService.class);
+    }
+
+    @Override
+    public DaemonTask setConfig(DaemonTaskConfig config) {
+        this.config = config;
+        return this;
+    }
+
+    @Override
+    public DaemonTaskConfig getConfig() {
+        return config;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public boolean dealTask() {
+        // Since flink-operator supports task redeployment and automatic recovery of failed jobs,
+        // we need to recheck the abnormal jobs here. If the job status has recovered to normal,
+        // put it back into the task monitoring queue.
+        log.info("Starting recheck of job instances...");
+
+        List<JobInstance> jobInstances = jobInstanceService.listJobInstancesToRecheck();
+        log.info("Found {} job instances to recheck", jobInstances.size());
+
+        FlinkJobThreadPool flinkJobThreadPool = FlinkJobThreadPool.getInstance();
+        for (JobInstance jobInstance : jobInstances) {
+            log.info(
+                    "Rechecking job instance: id={}, name={}, taskId={}",
+                    jobInstance.getId(),
+                    jobInstance.getName(),
+                    jobInstance.getTaskId());
+            JobInfoDetail jobInfoDetail = jobInstanceService.getJobInfoDetail(jobInstance.getId());
+            Optional<JobStatus> newStatus = this.recheckJobInstanceStatus(jobInfoDetail);
+            log.info("Job '{}' status after recheck: {}", jobInstance.getName(), newStatus.orElse(null));
+            if (newStatus.isPresent() && newStatus.get() == JobStatus.RUNNING) {
+                log.info("Job '{}' is RUNNING again, re-adding to monitoring queue", jobInstance.getName());
+                DaemonTaskConfig config =
+                        DaemonTaskConfig.build(FlinkJobTask.TYPE, jobInstance.getId(), jobInstance.getTaskId());
+                DaemonTask daemonTask = DaemonTask.build(config);
+                flinkJobThreadPool.execute(daemonTask);
+            }
+        }
+        log.info("Job recheck completed.");
+        return true;
+    }
+
+    private Optional<JobStatus> recheckJobInstanceStatus(JobInfoDetail jobInfoDetail) {
+        try {
+            String jmHost = jobInfoDetail.getClusterInstance().getJobManagerHost();
+            log.info("Querying job status from JobManager host: {}", jmHost);
+            List<JsonNode> jobs = FlinkAPI.build(jmHost).listJobs();
+            if (jobs == null || jobs.isEmpty()) {
+                log.warn("No jobs found on JobManager host: {}", jmHost);
+                return Optional.empty();
+            }
+            JsonNode firstJob = jobs.get(0);
+            log.debug("Job response: {}", firstJob.toString());
+            String newStatus = firstJob.get("state").asText();
+            log.info("Fetched job state: {}", newStatus);
+            return Optional.of(JobStatus.valueOf(newStatus));
+        } catch (Exception e) {
+            log.warn(
+                    "Failed to fetch job status, task: {}",
+                    jobInfoDetail.getInstance().getName());
+            return Optional.empty();
+        }
+    }
+}

--- a/dinky-admin/src/main/java/org/dinky/job/handler/JobRefreshHandler.java
+++ b/dinky-admin/src/main/java/org/dinky/job/handler/JobRefreshHandler.java
@@ -124,6 +124,8 @@ public class JobRefreshHandler {
 
         checkAndRefreshCluster(jobInfoDetail);
 
+        checkAndRefreshJobId(jobInfoDetail);
+
         // Update the value of JobData from the flink api while ignoring the null value to prevent
         // some other configuration from being overwritten
         BeanUtil.copyProperties(
@@ -223,6 +225,47 @@ public class JobRefreshHandler {
             }
         }
         return isDone;
+    }
+
+    /**
+     * In Flink operator mode, resource scaling triggers a job redeployment, which results in a new job ID.
+     * The system will update to the latest job ID accordingly.
+     *
+     *
+     * @param jobInfoDetail The job info detail.
+     */
+    public static void checkAndRefreshJobId(JobInfoDetail jobInfoDetail) {
+        if (!GatewayType.get(jobInfoDetail.getClusterInstance().getType()).isKubernetesApplicationMode()) {
+            return;
+        }
+
+        List<JsonNode> jobs = FlinkAPI.build(jobInfoDetail.getClusterInstance().getJobManagerHost())
+                .listJobs();
+        if (jobs == null || jobs.isEmpty()) {
+            log.info(
+                    "No running jobs found on task: {}",
+                    jobInfoDetail.getClusterInstance().getJobManagerHost());
+            return;
+        }
+
+        JsonNode firstJob = jobs.stream().findFirst().orElse(jobs.get(0));
+        String latestJobId = firstJob.get("jid").asText();
+        String currentJobId = jobInfoDetail.getInstance().getJid();
+        if (!latestJobId.equals(currentJobId)) {
+            JobInstance jobInstance = jobInfoDetail.getInstance();
+            jobInstance.setJid(latestJobId);
+            jobInstanceService.updateById(jobInstance);
+            log.info(
+                    "JobId for [{}] has been refreshed: {} -> {}",
+                    jobInfoDetail.getInstance().getName(),
+                    currentJobId,
+                    latestJobId);
+        } else {
+            log.debug(
+                    "JobId for [{}] is up to date: {}",
+                    jobInfoDetail.getInstance().getName(),
+                    currentJobId);
+        }
     }
 
     /**

--- a/dinky-admin/src/main/java/org/dinky/mapper/JobInstanceMapper.java
+++ b/dinky-admin/src/main/java/org/dinky/mapper/JobInstanceMapper.java
@@ -49,6 +49,9 @@ public interface JobInstanceMapper extends SuperMapper<JobInstance> {
     @InterceptorIgnore(tenantLine = "true")
     List<JobInstance> listJobInstanceActive();
 
+    @InterceptorIgnore(tenantLine = "true")
+    List<JobInstance> listJobInstancesToRecheck();
+
     JobInstance getJobInstanceByTaskId(Integer id);
 
     @InterceptorIgnore(tenantLine = "true")

--- a/dinky-admin/src/main/java/org/dinky/service/JobInstanceService.java
+++ b/dinky-admin/src/main/java/org/dinky/service/JobInstanceService.java
@@ -61,6 +61,8 @@ public interface JobInstanceService extends ISuperService<JobInstance> {
      */
     List<JobInstance> listJobInstanceActive();
 
+    List<JobInstance> listJobInstancesToRecheck();
+
     /**
      * Get the job information detail for the given ID.
      *

--- a/dinky-admin/src/main/java/org/dinky/service/impl/JobInstanceServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/JobInstanceServiceImpl.java
@@ -149,6 +149,11 @@ public class JobInstanceServiceImpl extends SuperServiceImpl<JobInstanceMapper, 
     }
 
     @Override
+    public List<JobInstance> listJobInstancesToRecheck() {
+        return baseMapper.listJobInstancesToRecheck();
+    }
+
+    @Override
     public JobInfoDetail getJobInfoDetail(Integer id) {
         if (Asserts.isNull(TenantContextHolder.get())) {
             initTenantByJobInstanceId(id);

--- a/dinky-admin/src/main/resources/META-INF/services/org.dinky.daemon.task.DaemonTask
+++ b/dinky-admin/src/main/resources/META-INF/services/org.dinky.daemon.task.DaemonTask
@@ -1,3 +1,4 @@
 org.dinky.job.FlinkJobTask
 org.dinky.job.SystemMetricsTask
 org.dinky.job.ClearJobHistoryTask
+org.dinky.job.RecheckJobTask

--- a/dinky-admin/src/main/resources/mapper/JobInstanceMapper.xml
+++ b/dinky-admin/src/main/resources/mapper/JobInstanceMapper.xml
@@ -91,6 +91,19 @@
         order by id desc
     </select>
 
+     <select id="listJobInstancesToRecheck" resultType="org.dinky.data.model.job.JobInstance">
+        select dji.*
+        from dinky_job_instance dji
+        join (
+            select task_id, max(create_time) as max_ct
+            from dinky_job_instance
+            group by task_id
+        ) latest
+        on dji.task_id = latest.task_id and dji.create_time = latest.max_ct
+        WHERE dji.status IN ('FAILED', 'CANCELED', 'FINISHED', 'UNKNOWN')
+        order by dji.id desc;
+    </select>
+
     <select id="getJobInstanceByTaskId" resultType="org.dinky.data.model.job.JobInstance">
         select *
         from dinky_job_instance


### PR DESCRIPTION
**问题**
在以下场景下，任务实际仍在运行，但 Dinky 显示任务状态为失败或未知，且任务名旁的小火苗消失：

1.  任务由 Flink Operator 管理，Operator对任务进行重新部署后导致jobId 发生变化。

2. 任务由 Flink Operator 管理，失败的任务被重新拉起并成功运行。

3. K8s 模式下，Dinky 启动任务超时，但任务实际已在 K8s 中启动成功。

4. K8s 模式下，任务 pod 被临时缩容为 0，导致 Dinky 误判为失败。

5. Dinky 获取 Flink 任务数据时，误将任务标记为未知。

**变更**
1. 更新任务信息时，先检查 jobId 是否变化，如变化则更新任务实例的 jobId。

2. 每隔五分钟检查一次失败任务，如发现任务已重新运行成功，则将其重新放回监控队列。