### PR TITLE
Fix 4372  Downgrade Guava to 31.1-jre to fix CDC pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <fastjson2.version>2.0.41</fastjson2.version>
         <flink.version>1.18.1</flink.version>
         <flyway.version>7.15.0</flyway.version>
-        <guava.version>32.1.3-jre</guava.version>
+        <guava.version>31.1-jre</guava.version>
         <h2database.version>1.4.200</h2database.version>
         <hamcrest.version>1.3</hamcrest.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>


### PR DESCRIPTION
## Purpose of the pull request

This pull request downgrades Guava from 32.1.3-jre to 31.1-jre to resolve CDC pipeline compatibility issues caused by classpath conflicts.

## Brief change log

Downgraded Guava version in pom.xml from  32.1.3-jre to 31.1-jre
close #4372

## Verify this pull request

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

