### PR TITLE
[fix] role menu update issue

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/service/impl/RoleMenuServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/RoleMenuServiceImpl.java
@@ -38,36 +38,28 @@ import cn.hutool.core.collection.CollUtil;
 @Service
 public class RoleMenuServiceImpl extends SuperServiceImpl<RoleMenuMapper, RoleMenu> implements RoleMenuService {
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public Result<Void> assignMenuToRole(AssignMenuToRoleDTO assignMenuToRoleDto) {
 
         if (CollUtil.isEmpty(assignMenuToRoleDto.getMenuIds())) {
             return Result.failed(Status.SELECT_MENU);
         }
-
-        int insertSize = 0;
         // 先删除原有的关系
-        List<RoleMenu> roleMenus = getBaseMapper()
-                .selectList(
-                        new LambdaQueryWrapper<RoleMenu>().eq(RoleMenu::getRoleId, assignMenuToRoleDto.getRoleId()));
-
-        // if not empty , delete all role menus
-        if (CollUtil.isNotEmpty(roleMenus)) {
-            roleMenus.forEach(rm -> {
-                getBaseMapper().delete(new LambdaQueryWrapper<RoleMenu>().eq(RoleMenu::getMenuId, rm.getMenuId()));
-            });
-        }
-
-        // then insert new role menus
-        for (Integer id : assignMenuToRoleDto.getMenuIds()) {
-            RoleMenu roleMenu = new RoleMenu();
-            roleMenu.setRoleId(assignMenuToRoleDto.getRoleId());
-            roleMenu.setMenuId(id);
-            insertSize += getBaseMapper().insert(roleMenu);
-        }
-
-        if (assignMenuToRoleDto.getMenuIds().size() == insertSize) {
+        getBaseMapper()
+                .delete(new LambdaQueryWrapper<RoleMenu>().eq(RoleMenu::getRoleId, assignMenuToRoleDto.getRoleId()));
+        List<RoleMenu> newRoles = assignMenuToRoleDto.getMenuIds().stream()
+                .map(menuId -> {
+                    RoleMenu roleMenu = new RoleMenu();
+                    roleMenu.setRoleId(assignMenuToRoleDto.getRoleId());
+                    roleMenu.setMenuId(menuId);
+                    return roleMenu;
+                })
+                .collect(Collectors.toList());
+        boolean res = saveBatch(newRoles);
+        if (res) {
             return Result.succeed(Status.ASSIGN_MENU_SUCCESS);
+        } else {
+            return Result.failed(Status.ASSIGN_MENU_FAILED);
         }
-        return Result.failed(Status.ASSIGN_MENU_FAILED);
     }
 }

--- a/dinky-admin/src/main/java/org/dinky/service/impl/RoleMenuServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/impl/RoleMenuServiceImpl.java
@@ -28,8 +28,10 @@ import org.dinky.mybatis.service.impl.SuperServiceImpl;
 import org.dinky.service.RoleMenuService;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 


### PR DESCRIPTION
## Purpose of the pull request

bug fix.

When updating the role menu, there is a bug in the current logic.
The correct process should be: first check if there are any rules associated with the current role_id. If such rules exist, we should delete all rules linked to this role_id.
However, the current logic deletes rules by menu_id, which ends up removing rules belonging to other roles as well.


## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
