### PR TITLE
[fix] add end time for jar sql

### DIFF
--- a/dinky-core/src/main/java/org/dinky/job/JobManager.java
+++ b/dinky-core/src/main/java/org/dinky/job/JobManager.java
@@ -275,6 +275,7 @@ public class JobManager {
                 setCurrentSql(jobStatement.getStatement());
                 jobRunnerFactory.getJobRunner(jobStatement.getStatementType()).run(jobStatement);
             }
+            job.setEndTime(LocalDateTime.now());
             if (job.isFailed()) {
                 failed();
             } else {


### PR DESCRIPTION
## Purpose of the pull request

<!--(For example: This pull request adds spotless plugin).-->

**Issue:** Missing end_time in dinky_history for executeJarSql jobs

**Expected Behavior:** The end_time field should record the actual job finish time.

**Current Behavior:**

- executeSql: Works correctly.

- executeJarSql: The end_time field is left blank.

**Root Cause:** The executeJarSql method lacks the step to update end_time.

**Required Action:**  Add logic to set the end_time upon completion of executeJarSql jobs.


