### PR TITLE
[Optimization-4511] Optimize catalogue tree loading performance for large-scale catalogue structures (2000+)

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/service/catalogue/context/CatalogueTreeBuildContext.java
+++ b/dinky-admin/src/main/java/org/dinky/service/catalogue/context/CatalogueTreeBuildContext.java
@@ -1,0 +1,57 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.dinky.service.catalogue.context;
+
+import cn.hutool.core.collection.CollectionUtil;
+import org.dinky.data.model.Catalogue;
+import org.dinky.data.model.Task;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CatalogueTreeBuildContext {
+    private final Map<Integer, List<Catalogue>> childMap;
+    private final Map<Integer, Task> taskMap;
+
+    public CatalogueTreeBuildContext(Map<Integer, List<Catalogue>> childMap, Map<Integer, Task> taskMap) {
+        this.childMap = childMap;
+        this.taskMap = taskMap;
+    }
+
+    public List<Catalogue> getChildren(Integer parentId) {
+        List<Catalogue> children = childMap.get(parentId);
+        if (CollectionUtil.isEmpty(children)) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>(children);
+    }
+
+    public boolean hasChild(Integer parentId) {
+        List<Catalogue> children = childMap.get(parentId);
+        return CollectionUtil.isNotEmpty(children);
+    }
+
+    public Task getTask(Integer taskId) {
+        if (taskId == null) {
+            return null;
+        }
+        return taskMap.get(taskId);
+    }
+}

--- a/dinky-admin/src/main/java/org/dinky/service/catalogue/context/CatalogueTreeBuildContext.java
+++ b/dinky-admin/src/main/java/org/dinky/service/catalogue/context/CatalogueTreeBuildContext.java
@@ -16,15 +16,17 @@
  *  limitations under the License.
  *
  */
+
 package org.dinky.service.catalogue.context;
 
-import cn.hutool.core.collection.CollectionUtil;
 import org.dinky.data.model.Catalogue;
 import org.dinky.data.model.Task;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import cn.hutool.core.collection.CollectionUtil;
 
 public class CatalogueTreeBuildContext {
     private final Map<Integer, List<Catalogue>> childMap;

--- a/dinky-admin/src/main/java/org/dinky/service/catalogue/impl/CatalogueServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/catalogue/impl/CatalogueServiceImpl.java
@@ -51,6 +51,7 @@ import org.dinky.service.JobInstanceService;
 import org.dinky.service.MonitorService;
 import org.dinky.service.TaskService;
 import org.dinky.service.catalogue.CatalogueService;
+import org.dinky.service.catalogue.context.CatalogueTreeBuildContext;
 import org.dinky.service.catalogue.factory.CatalogueFactory;
 import org.dinky.service.catalogue.factory.CatalogueTreeSortFactory;
 import org.dinky.service.catalogue.strategy.CatalogueTreeSortStrategy;
@@ -61,15 +62,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -141,11 +135,21 @@ public class CatalogueServiceImpl extends SuperServiceImpl<CatalogueMapper, Cata
                     .collect(Collectors.toList());
         }
         List<Task> taskList = taskService.list();
+
+        Map<Integer, List<Catalogue>> childMap = catalogueList.stream()
+                .collect(Collectors.groupingBy(
+                        Catalogue::getParentId, LinkedHashMap::new, Collectors.toList()));
+        Map<Integer, Task> taskMap = taskList.stream()
+                .filter(task -> task.getId() != null)
+                .collect(Collectors.toMap(Task::getId, Function.identity(), (existing, replacement) -> existing));
+        CatalogueTreeBuildContext context = new CatalogueTreeBuildContext(childMap, taskMap);
+
+
         List<Catalogue> returnList = new ArrayList<>();
         for (Catalogue catalogue : catalogueList) {
             //  get all child catalogue of parent catalogue id , the 0 is root catalogue
             if (catalogue.getParentId() == 0) {
-                recursionBuildCatalogueAndChildren(catalogueList, catalogue, taskList);
+                recursionBuildCatalogueAndChildren(catalogue, context);
                 returnList.add(catalogue);
             }
         }
@@ -161,22 +165,18 @@ public class CatalogueServiceImpl extends SuperServiceImpl<CatalogueMapper, Cata
      * @param list
      * @param catalogues
      */
-    private void recursionBuildCatalogueAndChildren(List<Catalogue> list, Catalogue catalogues, List<Task> taskList) {
-        // 得到子节点列表
-        List<Catalogue> childList = getChildList(list, catalogues);
+    private void recursionBuildCatalogueAndChildren(Catalogue catalogues, CatalogueTreeBuildContext context) {
+        List<Catalogue> childList = context.getChildren(catalogues.getId());
         catalogues.setChildren(childList);
         for (Catalogue tChild : childList) {
-            if (hasChild(list, tChild)) {
-                // Determine whether there are child nodes
-                for (Catalogue children : childList) {
-                    recursionBuildCatalogueAndChildren(list, children, taskList);
-                }
+            if (context.hasChild(tChild.getId())) {
+                recursionBuildCatalogueAndChildren(tChild, context);
             } else {
                 if (tChild.getIsLeaf() || null != tChild.getTaskId()) {
-                    taskList.stream()
-                            .filter(t -> t.getId().equals(tChild.getTaskId()))
-                            .findFirst()
-                            .ifPresent(tChild::setTaskAndNote);
+                    Task task = context.getTask(tChild.getTaskId());
+                    if (task != null) {
+                        tChild.setTaskAndNote(task);
+                    }
                 }
             }
         }

--- a/dinky-admin/src/main/java/org/dinky/service/catalogue/impl/CatalogueServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/catalogue/impl/CatalogueServiceImpl.java
@@ -62,7 +62,16 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.LinkedHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 

--- a/dinky-admin/src/main/java/org/dinky/service/catalogue/impl/CatalogueServiceImpl.java
+++ b/dinky-admin/src/main/java/org/dinky/service/catalogue/impl/CatalogueServiceImpl.java
@@ -66,12 +66,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.LinkedHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -146,13 +146,11 @@ public class CatalogueServiceImpl extends SuperServiceImpl<CatalogueMapper, Cata
         List<Task> taskList = taskService.list();
 
         Map<Integer, List<Catalogue>> childMap = catalogueList.stream()
-                .collect(Collectors.groupingBy(
-                        Catalogue::getParentId, LinkedHashMap::new, Collectors.toList()));
+                .collect(Collectors.groupingBy(Catalogue::getParentId, LinkedHashMap::new, Collectors.toList()));
         Map<Integer, Task> taskMap = taskList.stream()
                 .filter(task -> task.getId() != null)
                 .collect(Collectors.toMap(Task::getId, Function.identity(), (existing, replacement) -> existing));
         CatalogueTreeBuildContext context = new CatalogueTreeBuildContext(childMap, taskMap);
-
 
         List<Catalogue> returnList = new ArrayList<>();
         for (Catalogue catalogue : catalogueList) {


### PR DESCRIPTION
The main change is the pre-construction of parent → children and taskId → Task maps, which are then reused during recursion. This avoids repeated scans and is the key improvement for performance。
<img width="864" height="373" alt="image" src="https://github.com/user-attachments/assets/6af80a37-c0b1-4618-98ed-eecaf7e78ee8" />
