### PR TITLE
Bug fix: resolve pagination error when changing pages on the Registry

### DIFF
--- a/dinky-admin/src/main/java/org/dinky/mybatis/util/ProTableUtil.java
+++ b/dinky-admin/src/main/java/org/dinky/mybatis/util/ProTableUtil.java
@@ -73,7 +73,7 @@ public class ProTableUtil {
 
     private static void buildSort(
             String sortField, String sortValue, QueryWrapper<?> wrapper, boolean camelToUnderscore) {
-        if (sortField != null && sortValue != null) {
+        if (sortField != null && sortValue != null && !"undefined".equals(sortField)) {
             if (camelToUnderscore) {
                 sortField = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, sortField);
             }
@@ -91,7 +91,7 @@ public class ProTableUtil {
 
     private static void buildFilter(
             String searchField, JsonNode searchValue, QueryWrapper<?> wrapper, boolean camelToUnderscore) {
-        if (searchField != null && !searchField.equals("") && searchValue != null) {
+        if (searchField != null && !searchField.equals("") && !"undefined".equals(searchField) && searchValue != null) {
             if (camelToUnderscore) {
                 searchField = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, searchField);
             }


### PR DESCRIPTION
Purpose of the pull request

Fix a pagination error that occurs when switching pages on the Registry → Documents page while no sorting is applied.
<img width="2996" height="1450" alt="shot_2026-01-06_18 05 58" src="https://github.com/user-attachments/assets/629ddaea-273a-4e19-b3c5-39fae51acb9d" />

console err log:
```javascript
9876.6bb72816.async.js:1 Uncaught (in promise) Error: BizError: 
### Error querying database.  Cause: java.sql.SQLSyntaxErrorException: Unknown column 'a.undefined' in 'order clause'
### The error may exist in class path resource [mapper/DocumentMapper.xml]
### The error may involve defaultParameterMap
### The error occurred while setting parameters
### SQL: SELECT a.* FROM dinky_flink_document a WHERE 1 = 1 ORDER BY a.undefined ASC LIMIT ?,?
### Cause: java.sql.SQLSyntaxErrorException: Unknown column 'a.undefined' in 'order clause'
; bad SQL grammar []; nested exception is java.sql.SQLSyntaxErrorException: Unknown column 'a.undefined' in 'order clause'
    at 9876.6bb72816.async.js:1:84633
    at umi.d680b043.js:1199:5640
    at Generator.<anonymous> (umi.d680b043.js:1199:3053)
    at Generator.throw (umi.d680b043.js:1199:1801)
    at n (umi.d680b043.js:1198:3564)
```

Brief change log
- Fix pagination logic to handle unsorted document lists correctly
- Prevent page switching errors when sort parameters are missing or unset

Verify this pull request

This change added no new automated tests and can be verified as follows:
- Manually verified by accessing the Registry → Documents page without applying any sort
- Switched between different page numbers and confirmed no errors occur
- Verified normal pagination behavior when sorting is applied