### PR TITLE
Fix Kerberos authentication when submitting tasks to the k8s session

### DIFF
--- a/dinky-alert/dinky-alert-email/src/main/java/org/dinky/alert/email/params/EmailParams.java
+++ b/dinky-alert/dinky-alert-email/src/main/java/org/dinky/alert/email/params/EmailParams.java
@@ -38,7 +38,7 @@ public class EmailParams {
     private Integer serverPort;
     private String sender;
     private Boolean enableSmtpAuth;
-    private Boolean starttlsEnable;
+    private Boolean starttlsEnable = false;
     private Boolean sslEnable;
     private String user;
     private String password;

--- a/dinky-core/src/main/java/org/dinky/executor/Executor.java
+++ b/dinky-core/src/main/java/org/dinky/executor/Executor.java
@@ -190,6 +190,8 @@ public abstract class Executor {
         if (executorConfig.isValidConfig()) {
             for (Map.Entry<String, String> entry : executorConfig.getConfig().entrySet()) {
                 configuration.setString(entry.getKey(), entry.getValue());
+                setConfig.put(entry.getKey(), entry.getValue());
+                logger.info("setConfig key: [{}], value: [{}]", entry.getKey(), entry.getValue());
             }
         }
         if (executorConfig.isValidVariables()) {


### PR DESCRIPTION
[Fix-4539] Fix Kerberos authentication when submitting tasks to the k8s session cluster and fix the issue of alert instance creation failure.
modify description：
1、The setConfig method in the Executor did not assign the Flink configuration (affecting Kerberos authentication in KerberosUtil).
2、Provided a default value for starttlsEnable in EmailParams to avoid a Null Exception in setStarttlsEnable when configuring the email settings for the first time with empty values.

