### PR TITLE
[Feature] Support customizing JVM memory options via JVM_OPTS environment variable

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -7,6 +7,7 @@ ARG FLINK_VERSION
 ENV FLINK_VERSION=${FLINK_VERSION}
 ENV DINKY_HOME=/opt/dinky/
 ENV H2_DB=./tmp/db/h2
+ENV JVM_OPTS="-XX:+UseContainerSupport -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"
 
 
 USER root
@@ -18,7 +19,7 @@ ADD  build/dist/ /opt/dinky/config/static
 WORKDIR /opt/dinky/
 
 
-RUN mkdir /opt/dinky/customJar && chmod -R 777 /opt/dinky/ && sed -i 's/-Xms512M -Xmx2048M -XX:PermSize=512M/-XX:+UseContainerSupport -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0/g' ./bin/auto.sh
+RUN mkdir /opt/dinky/customJar && chmod -R 777 /opt/dinky/
 
 EXPOSE 8888
 

--- a/script/bin/auto.sh
+++ b/script/bin/auto.sh
@@ -180,7 +180,7 @@ JAR_PARAMS_OPT="--logging.config=${LOG_CONFIG}"
 # JMX path
 JMX="-javaagent:$APP_HOME/lib/jmx_prometheus_javaagent-0.20.0.jar=10087:$APP_HOME/config/jmx/jmx_exporter_config.yaml"
 #JVM OPTS
-JVM_OPTS="-Xms512M -Xmx2048M -XX:PermSize=512M -XX:MaxPermSize=1024M"
+JVM_OPTS="${JVM_OPTS:--Xms512M -Xmx2048M -XX:PermSize=512M -XX:MaxPermSize=1024M}"
 
 # Check whether the pid path exists
 PID_PATH="${APP_HOME}/run"


### PR DESCRIPTION
## Purpose of the pull request

Previously, JVM memory options in auto.sh were hardcoded as -Xms512M -Xmx2048M -XX:PermSize=512M -XX:MaxPermSize=1024M, and the Dockerfile worked around this by using sed to replace
  the values at image build time with container-aware settings (-XX:+UseContainerSupport).

  This PR removes the sed hack and introduces a cleaner approach:

  - auto.sh now reads JVM options from the JVM_OPTS environment variable, falling back to the original hardcoded defaults if not set.
  - The Dockerfile declares JVM_OPTS as an ENV variable with container-aware defaults (-XX:+UseContainerSupport -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0).

  Benefits:
  - Users can override JVM memory settings at runtime without rebuilding the image:
  docker run -e JVM_OPTS="-Xms1g -Xmx4g" dinky:latest
  - Non-container deployments retain the original default values when JVM_OPTS is not set.
  - Eliminates the fragile sed substitution that could silently fail if the hardcoded string changed.

## Brief change log

<!--*(for example:)*
  - *Add spotless-maven-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dinky-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
