### PR TITLE
fix(cdc): normalize zero length varchar metadata

### DIFF
--- a/dinky-cdc/dinky-cdc-core/src/main/java/org/dinky/cdc/convert/DataTypeConverter.java
+++ b/dinky-cdc/dinky-cdc-core/src/main/java/org/dinky/cdc/convert/DataTypeConverter.java
@@ -100,8 +100,15 @@ public class DataTypeConverter {
                 return new VarBinaryType(Integer.MAX_VALUE);
             case STRING:
             default:
-                return new VarCharType(Asserts.isNull(column.getLength()) ? Integer.MAX_VALUE : column.getLength());
+                return new VarCharType(normalizeVarCharLength(column.getLength()));
         }
+    }
+
+    private static int normalizeVarCharLength(Integer length) {
+        if (Asserts.isNull(length) || length < VarCharType.MIN_LENGTH) {
+            return VarCharType.MAX_LENGTH;
+        }
+        return length;
     }
 
     public static Object convertToRow(Object value, LogicalType logicalType, ZoneId timeZone) {

--- a/dinky-cdc/dinky-cdc-core/src/test/java/org/dinky/cdc/convert/DataTypeConverterTest.java
+++ b/dinky-cdc/dinky-cdc-core/src/test/java/org/dinky/cdc/convert/DataTypeConverterTest.java
@@ -19,13 +19,35 @@
 
 package org.dinky.cdc.convert;
 
+import org.dinky.data.model.Column;
+import org.dinky.data.types.DataTypes;
+
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarCharType;
 
 import java.time.ZoneId;
 
 import org.junit.Assert;
+import org.junit.Test;
 
 public class DataTypeConverterTest {
+
+    @Test
+    public void testGetLogicalTypeWithZeroLengthString() {
+        Column column = Column.builder()
+                .name("enum_column")
+                .type("VARCHAR")
+                .isNullable(true)
+                .length(0)
+                .dataType(DataTypes.VARCHAR.toColumnType(true, 0))
+                .build();
+
+        LogicalType logicalType = DataTypeConverter.getLogicalType(column);
+
+        Assert.assertTrue(logicalType instanceof VarCharType);
+        Assert.assertEquals(VarCharType.MAX_LENGTH, ((VarCharType) logicalType).getLength());
+    }
 
     // todo: check the time zone of Timestamp
     //    @Test


### PR DESCRIPTION
## Purpose

Fixes #4556.

When CDC metadata contains a string-like column with length `0` (for example from a MySQL `ENUM` column), `DataTypeConverter#getLogicalType` passed that value directly to Flink's `VarCharType`. Flink rejects `VARCHAR(0)` and throws:

```
Variable character string length must be between 1 and 2147483647
```

## Changes

- Normalize null or invalid varchar lengths to `VarCharType.MAX_LENGTH` before creating the Flink logical type.
- Add a regression test for a zero-length varchar column mapped through `DataTypeConverter`.

## Verification

Ran locally with JDK 17:

```
./mvnw -Pflink-single-version,flink-1.18 \
  -pl dinky-flink,dinky-client,dinky-cdc/dinky-cdc-core \
  -am -Dtest=DataTypeConverterTest -DfailIfNoTests=false test
```

Result: build success, `DataTypeConverterTest` passed.
