### PR TITLE
fix(metadata): map PostgreSQL money to decimal

### DIFF
--- a/dinky-metadata/dinky-metadata-postgresql/src/main/java/org/dinky/metadata/convert/PostgreSqlTypeConvert.java
+++ b/dinky-metadata/dinky-metadata-postgresql/src/main/java/org/dinky/metadata/convert/PostgreSqlTypeConvert.java
@@ -39,9 +39,9 @@ public class PostgreSqlTypeConvert extends AbstractJdbcTypeConvert {
         boolean isNullable = !column.isKeyFlag() && column.isNullable();
         final LogicalTypeParam logicalTypeParam =
                 LogicalTypeParam.of(isNullable, length, column.getPrecision(), column.getScale());
-        if (type.contains("numeric") || type.contains("decimal")) {
-            int intValue = column.getPrecision().intValue();
-            if (intValue > 38) {
+        if (type.contains("numeric") || type.contains("decimal") || type.contains("money")) {
+            Integer precision = column.getPrecision();
+            if (Asserts.isNotNull(precision) && precision > 38) {
                 return ColumnType.of(DataTypes.STRING, DataTypes.STRING.copyLogicalType(logicalTypeParam));
             }
             return ColumnType.of(DataTypes.DECIMAL, DataTypes.DECIMAL.copyLogicalType(logicalTypeParam));

--- a/dinky-metadata/dinky-metadata-postgresql/src/test/java/org/dinky/metadata/driver/PostgreSqlDriverTest.java
+++ b/dinky-metadata/dinky-metadata-postgresql/src/test/java/org/dinky/metadata/driver/PostgreSqlDriverTest.java
@@ -23,7 +23,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.dinky.data.model.Column;
 import org.dinky.data.model.Table;
+import org.dinky.data.types.ColumnType;
 import org.dinky.data.types.DataTypes;
+import org.dinky.metadata.convert.PostgreSqlTypeConvert;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -144,5 +146,20 @@ class PostgreSqlDriverTest {
                 + "COMMENT ON COLUMN \"public\".\"user\".\"birthday\" IS '生日';\n"
                 + "COMMENT ON COLUMN \"public\".\"user\".\"register_time\" IS '注册时间';\n";
         assertEquals(expect, tableDDL);
+    }
+
+    @Test
+    void convertMoneyTypeToDecimal() {
+        Column moneyColumn = Column.builder()
+                .name("balance")
+                .type("money")
+                .precision(19)
+                .scale(2)
+                .isNullable(true)
+                .build();
+
+        ColumnType columnType = new PostgreSqlTypeConvert().convert(moneyColumn);
+
+        assertEquals(DataTypes.DECIMAL, columnType.getValue());
     }
 }


### PR DESCRIPTION
## Purpose

Fixes #4557.

PostgreSQL `money` columns were falling through the metadata type converter and being reported as `STRING`. This maps `money` together with the other PostgreSQL numeric types so it is exposed as Dinky `DECIMAL` metadata.

## Changes

- Treat PostgreSQL `money` as a decimal-compatible type in `PostgreSqlTypeConvert`.
- Avoid dereferencing a null precision while checking the existing PostgreSQL decimal precision guard.
- Add a regression test for `money` metadata conversion.

## Verification

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) PATH="$JAVA_HOME/bin:$PATH" \
  ./mvnw -pl dinky-metadata/dinky-metadata-postgresql -am \
  -Dtest=PostgreSqlDriverTest#convertMoneyTypeToDecimal \
  -DfailIfNoTests=false test

JAVA_HOME=$(/usr/libexec/java_home -v 17) PATH="$JAVA_HOME/bin:$PATH" \
  ./mvnw -pl dinky-metadata/dinky-metadata-postgresql -am \
  -Dtest=PostgreSqlDriverTest \
  -DfailIfNoTests=false test

JAVA_HOME=$(/usr/libexec/java_home -v 17) PATH="$JAVA_HOME/bin:$PATH" \
  ./mvnw -pl dinky-metadata/dinky-metadata-postgresql -am test
```

All three commands passed locally.
