### PR TITLE
[Fix-4574][web] Prevent repeated project tree refresh

### DIFF
--- a/dinky-web/src/pages/DataStudio/Toolbar/Project/index.tsx
+++ b/dinky-web/src/pages/DataStudio/Toolbar/Project/index.tsx
@@ -165,6 +165,7 @@ export const Project = (props: any) => {
       case DataStudioActionType.PROJECT_REFRESH:
         setInitDid(true);
         refresh();
+        updateAction({ actionType: null, params: null });
         break;
     }
   }, [actionType, params, data, treeData]);


### PR DESCRIPTION
## Purpose of the pull request

Prevent the Data Studio project tree from entering a repeated refresh loop after the toolbar refresh button is clicked.

Closes #4574.

## Brief change log

- Clear the one-shot `PROJECT_REFRESH` action immediately after dispatching the catalogue tree refresh.
- Prevent refreshed `data` from retriggering the same action and requesting `getCatalogueTreeData` indefinitely.

## Verify this pull request

This change is not covered by automated UI tests and was verified as follows:

- `prettier --check src/pages/DataStudio/Toolbar/Project/index.tsx`
- `git diff --check`
- Confirmed the refreshed `data` can no longer re-enter the `PROJECT_REFRESH` branch because the action is cleared.

The repository-wide TypeScript check currently reports pre-existing dependency and generated-module errors after a lockfile-free install; no new error is associated with this change.